### PR TITLE
[DOCU-1747] Default ports topic

### DIFF
--- a/app/_data/docs_nav_gateway_2.5.x.yml
+++ b/app/_data/docs_nav_gateway_2.5.x.yml
@@ -41,6 +41,8 @@
       url: /plan-and-deploy/performance-testing-framework
     - text: DNS Considerations
       url: /plan-and-deploy/dns-considerations
+    - text: Default Ports
+      url: /plan-and-deploy/default-ports
 
 - title: Configure
   icon: /assets/images/icons/konnect/konnect-settings.svg

--- a/app/gateway/2.5.x/plan-and-deploy/default-ports.md
+++ b/app/gateway/2.5.x/plan-and-deploy/default-ports.md
@@ -1,0 +1,24 @@
+---
+title: Default Ports
+toc: false
+---
+By default, {{site.base_gateway}} listens on the following ports:
+
+| Port                                                                               | Protocol | Description | Gateway tier |
+|:-----------------------------------------------------------------------------------|:---------|:------------|:----------------------|
+| [`:8000`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)      | HTTP     | Takes incoming HTTP traffic from **Consumers**, and forwards it to upstream  **Services**. | All tiers and modes |
+| [`:8443`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from **Consumers**, and forwards it to upstream **Services**. | All tiers and modes |
+| [`:8001`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
+| [`:8444`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
+| [`:8005`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
+| [`:8006`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | All tiers and modes |
+| [`:8002`](/enterprise/{{page.kong_version}}/property-reference/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |
+| [`:8445`](/enterprise/{{page.kong_version}}/property-reference/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | {{site.base_gateway}} free mode |
+| [`:8003`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
+| [`:8446`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**.  | {{site.base_gateway}} Enterprise tier |
+| [`:8004`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
+| [`:8447`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
+
+{:.note}
+> **Note:** Kong Gateway free mode and Enterprise tier are not available for
+open-source Gateway packages.


### PR DESCRIPTION
### Review
@falondarville 

### Summary
Moving default ports topic from enterprise to gateway. Content applies to both, so I added a table column to distinguish what entry applies to what. 

### Reason
DOCU-1747, single-sourcing project.

### Testing
N/A
