### PR TITLE
[DOCU-1914] Audit and move Kong Manager docs

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -103,6 +103,7 @@
               url: /configure/auth/kong-manager/oidc
             - text: Sessions
               url: /configure/auth/kong-manager/sessions
+
         - text: Role-based Access Control (RBAC)
           url: /configure/auth/rbac
           items:
@@ -112,18 +113,9 @@
               url: /configure/auth/rbac/add-user
             - text: Add an Admin
               url: /configure/auth/rbac/add-admin
-
         - text: Mapping LDAP Service Directory Groups to Kong Roles
           url: /configure/auth/service-directory-mapping
 
-    - text: Configure Gateway Objects
-      items:
-        - text: Add a Service
-          url: /configure/add-service
-        - text: Enable a Plugin
-          url: /configure/enable-plugin
-        - text: Add a Consumer
-          url: /configure/add-consumer
     - text: Configure gRPC Plugins
       url: /configure/grpc
     - text: Logging Reference

--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -75,20 +75,61 @@
               url: /configure/auth/oidc-auth0
             - text: OpenID Connect with Cognito
               url: /configure/auth/oidc-cognito
+            - text: OIDC Authenticated Group Mapping
+              url: /configure/auth/oidc-mapping
             - text: OpenID Connect Plugin Reference
               url: /hub/kong-inc/openid-connect
               absolute_url: true
-        - text: Multiple Authentication Methods
+        - text: Allowing Multiple Authentication Methods
           url: /configure/auth/allowing-multiple-authentication-methods
+        - text: Auth for Kong Manager
+          url: /configure/auth/kong-manager
+          items:
+            - text: Create a Super Admin
+              url: /configure/auth/kong-manager/super-admin
+            - text: Configure Networking
+              url: /configure/auth/kong-manager/networking
+            - text: Configure Kong Manager to Send Email
+              url: /configure/auth/kong-manager/email
+            - text: Reset Passwords and RBAC Tokens
+              url: /configure/auth/kong-manager/reset-password/
+            - text: Configure Workspaces
+              url: /configure/auth/kong-manager/workspaces
+            - text: Basic Auth
+              url: /configure/auth/kong-manager/basic
+            - text: LDAP
+              url: /configure/auth/kong-manager/ldap
+            - text: OIDC
+              url: /configure/auth/kong-manager/oidc
+            - text: Sessions
+              url: /configure/auth/kong-manager/sessions
+        - text: Role-based Access Control (RBAC)
+          url: /configure/auth/rbac
+          items:
+            - text: Add a Role
+              url: /configure/auth/rbac/add-role
+            - text: Add a User
+              url: /configure/auth/rbac/add-user
+            - text: Add an Admin
+              url: /configure/auth/rbac/add-admin
+
+        - text: Mapping LDAP Service Directory Groups to Kong Roles
+          url: /configure/auth/service-directory-mapping
+
+    - text: Configure Gateway Objects
+      items:
+        - text: Add a Service
+          url: /configure/add-service
+        - text: Enable a Plugin
+          url: /configure/enable-plugin
+        - text: Add a Consumer
+          url: /configure/add-consumer
     - text: Configure gRPC Plugins
       url: /configure/grpc
     - text: Logging Reference
       url: /configure/logging
     - text: Network and Firewall
       url: /configure/network
-
-- title: Administer
-  icon: /assets/images/icons/documentation/icn-admin-api-color.svg
 
 - title: Monitor
   icon: /assets/images/icons/documentation/icn-vitals.svg

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -91,6 +91,7 @@ page.kong_latest.release %}
               <a href="https://konghq.com/pricing" {%
                 if page.badge == 'plus' %}class="badge plus" aria-label="available with plus subscription"{% endif %}{%
                 if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with enterprise subscription"{% endif %}{%
+                if page.badge == 'free' %}class="badge free" aria-label="available in Kong Gateway free mode"{% endif %}{%
                 if page.badge == 'oss' %}class="badge oss" aria-label="open-source only"{% endif %}>
               </a>
               {% endif %}

--- a/app/gateway/2.6.x/configure/auth/kong-manager/basic.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/basic.md
@@ -1,0 +1,41 @@
+---
+title: Enable Basic Auth for Kong Manager
+badge: free
+---
+
+### Prerequisites
+
+To enable Basic Authentication, configure Kong with the following properties:
+
+```
+enforce_rbac = on
+admin_gui_auth = basic-auth
+admin_gui_session_conf = { "secret":"set-your-string-here" }
+```
+
+The **Sessions Plugin** requries a secret and is configured securely by default.
+
+* Under all circumstances, the `secret` must be manually set to a string.
+* If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
+* If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
+Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+
+## Step 1
+
+Start Kong:
+
+```
+$ kong start [-c /path/to/kong/conf]
+```
+
+## Step 2
+
+If you created a **Super Admin** via database migration, log in to Kong
+Manager with the username `kong_admin` and the password
+set in the environment variable.
+
+If you created a Super Admin via the Kong Manager "Organization" tab
+as described in
+[How to Create a Super Admin](/enterprise/{{page.kong_version}}/kong-manager/authentication/super-admin),
+log in with the credentials you created after accepting the email
+invitation.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/email.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/email.md
@@ -1,0 +1,23 @@
+---
+title: Configuring Kong Manager to Send Email
+badge: free
+---
+
+A **Super Admin** can invite other **Admins** to register in Kong Manager, and **Admins**
+can reset their passwords using "Forgot Password" functionality. Both of these
+workflows use email to communicate with the user.
+
+Emails from Kong Manager require the following configuration:
+
+* [`admin_emails_from`](/enterprise/{{page.kong_version}}/property-reference/#admin_emails_from)
+* [`admin_emails_reply_to`](/enterprise/{{page.kong_version}}/property-reference/#admin_emails_reply_to)
+* [`admin_invitation_expiry`](/enterprise/{{page.kong_version}}/property-reference/#admin_invitation_expiry)
+
+Kong does not check for the validity of email
+addresses set in the configuration. If the SMTP settings are
+configured incorrectly, e.g., if they point to a non-existent
+email address, Kong Manager will _not_ display an error message.
+
+For additional information about SMTP, refer to the
+[general SMTP configuration](/enterprise/{{page.kong_version}}/property-reference/#general-smtp-configuration)
+shared by Kong Manager and Dev Portal.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/index.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/index.md
@@ -1,0 +1,68 @@
+---
+title: Securing Kong Manager
+badge: free
+---
+
+## What Can Admins Do in Kong Manager?
+
+Kong Manager enables users with **Admin** accounts to access Kong entities such
+as **Services**, **Plugins**, and **Consumers.**
+
+The following document summarizes Kong Manager's controls for *authentication*
+and *authorization*.
+
+## Configuring Authentication
+
+Kong Enterprise comes packaged with **Authentication Plugins** that can be used
+to secure Kong Manager. Unlike enabling a **Plugin** on an entity or cluster,
+enabling an **Authentication Plugin** for *only* Kong Manager requires turning
+on `enforce_rbac`, setting `admin_gui_auth` to the desired type, proper
+configuration of `admin_gui_session_conf`, and configuring `admin_gui_auth_conf`
+if needed.
+
+Kong Manager currently supports the following **Authentication Plugins**:
+
+* [**Basic Auth**](/enterprise/{{page.kong_version}}/kong-manager/authentication/basic/)
+* [**OIDC**](/enterprise/{{page.kong_version}}/kong-manager/authentication/oidc/)
+* [**LDAP**](/enterprise/{{page.kong_version}}/kong-manager/authentication/ldap/)
+
+In addition to the **Authentication Plugins** above, the new
+[**Sessions Plugin**](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/)
+is now required when RBAC is enabled. It sends HTTP cookies to authenticate
+client requests and maintain session information.
+
+The **Sessions Plugin** requries a secret and is configured
+securely by default.
+* Under all circumstances, the `secret` must be manually set to a string.
+* If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
+* If using different domains for the Admin API and Kong Manager,
+`cookie_samesite` must be set to `off`.
+Learn more about these properties in
+[Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security),
+and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+
+## Access Control with Roles and Workspaces
+
+An **Admin** belongs to a **Workspace** and should have at least one **Role**
+with a set of **Permissions**. If an **Admin** is in a **Workspace** *without*
+a **Role**, they will not have the ability to see or interact with anything.
+
+By creating separate
+[**Workspaces**](/enterprise/{{page.kong_version}}/kong-manager/administration/workspaces/workspaces/),
+ an organization with multiple teams can segment its Kong cluster so that
+ different teams do not have access to each other's Kong entities.
+
+Kong Enterprise implements Role-Based Access Control
+([RBAC](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac/)).
+**Admins** are assigned **Roles** that have clearly defined **Permissions**. A
+**Super Admin** has the ability to:
+
+* further customize **Permissions**
+* create entirely new **Roles**
+* invite or deactivate **Admins**
+* assign or revoke their **Roles**
+
+In Kong Manager, limiting **Permissions** also restricts the visibility of the
+application interface and navigation. Learn more about RBAC in Kong Manager in
+our guide
+[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac).

--- a/app/gateway/2.6.x/configure/auth/kong-manager/ldap.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/ldap.md
@@ -1,0 +1,67 @@
+---
+title: Enable LDAP for Kong Manager
+badge: enterprise
+---
+
+## Enable LDAP
+
+Kong Enterprise offers the ability to bind authentication for Kong Manager
+*Admins* to a company's Active Directory using the
+[LDAP Authentication Advanced plugin](/hub/kong-inc/ldap-auth-advanced).
+
+Using the configuration below, it is unnecessary to
+manually apply the **Plugin**; the configuration alone will enable LDAP
+Authentication for Kong Manager.
+
+Ensure Kong is configured with the following properties either in the
+configuration file or using environment variables:
+
+```
+admin_gui_auth = ldap-auth-advanced
+enforce_rbac = on
+admin_gui_session_conf = { "secret":"set-your-string-here" }
+admin_gui_auth_conf = {                                       \
+    "anonymous":"",                                           \
+    "attribute":"<ENTER_YOUR_ATTRIBUTE_HERE>",                \
+    "bind_dn":"<ENTER_YOUR_BIND_DN_HERE>",                    \
+    "base_dn":"<ENTER_YOUR_BASE_DN_HERE>",                    \
+    "cache_ttl": 2,                                           \
+    "consumer_by":["username", "custom_id"],                  \
+    "header_type":"Basic",                                    \
+    "keepalive":60000,                                        \
+    "ldap_host":"<ENTER_YOUR_LDAP_HOST_HERE>",                \
+    "ldap_password":"<ENTER_YOUR_LDAP_PASSWORD_HERE>",        \
+    "ldap_port":389,                                          \
+    "start_tls":false,                                        \
+    "timeout":10000,                                          \
+    "verify_ldap_host":true                                   \
+}
+```
+
+* `"attribute":"<ENTER_YOUR_ATTRIBUTE_HERE>"`: The attribute used to identify LDAP users
+    * For example, to map LDAP users to admins by their username, `"attribute":"uid"`
+* `"bind_dn":"<ENTER_YOUR_BIND_DN_HERE>"`: LDAP Bind DN (Distinguished Name)
+    * Used to perform LDAP search of user. This bind_dn should have permissions to search
+      for the user being authenticated.
+    * For example, `uid=einstein,ou=scientists,dc=ldap,dc=com`
+* `"base_dn":"<ENTER_YOUR_BASE_DN_HERE>"`: LDAP Base DN (Distinguished Name)
+    * For example, `ou=scientists,dc=ldap,dc=com`
+* `"ldap_host":"<ENTER_YOUR_LDAP_HOST_HERE>"`: LDAP host domain
+    * For example, `"ec2-XX-XXX-XX-XXX.compute-1.amazonaws.com"`
+* `"ldap_password":"<ENTER_YOUR_LDAP_PASSWORD_HERE>"`: LDAP password
+    * *Note*: As with any configuration property, sensitive information may be set as an
+      environment variable instead of being written directly in the configuration file.
+
+The **Sessions Plugin** requries a secret and is configured securely by default.
+* Under all circumstances, the `secret` must be manually set to a string.
+* If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
+* If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
+Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+
+After starting Kong with the desired configuration, you can create new *Admins*
+whose usernames match those in the AD. Those users will then be able to accept
+invitations to join Kong Manager and log in with their LDAP credentials.
+
+### Using Service Directory Mapping on the CLI
+
+{% include /md/{{page.kong_version}}/ldap/ldap-service-directory-mapping.md %}

--- a/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
@@ -1,0 +1,104 @@
+---
+title: Default and Custom Networking Configuration for Kong Manager
+badge: free
+---
+
+## Default Configuration
+
+By default, Kong Manager starts up without authentication (see
+[`admin_gui_auth`]), and it assumes that the Admin API is available
+on port 8001 (see [Default Ports](/enterprise/{{page.kong_version}}/deployment/default-ports) of the same host that serves
+Kong Manager.
+
+## Custom Configuration
+
+Common configurations to enable are
+
+* Serving Kong Manager from a dedicated Kong node
+
+  When Kong Manager is on a dedicated Kong node, it must make
+  external calls to the Admin API. Set [`admin_api_uri`] to the
+  location of your Admin API.
+
+* Securing Kong Manager through a **Kong Authentication Plugin**
+
+  When Kong Manager is **secured through an Authentication Plugin**
+  and _not_ on a dedicated node, it makes calls to the Admin API on
+  the same host. By default, the Admin API listens on ports 8001 and
+  8444 on localhost. Change [`admin_listen`] if necessary, or set
+  [`admin_api_uri`].
+
+* Securing Kong Manager and serving it from a dedicated node
+
+  When Kong Manager is **secured and served from a dedicated node**,
+  set [`admin_api_uri`] to the location of the Admin API.
+
+The table below summarizes which properties to set (or defaults to
+verify) when configuring Kong Manager connectivity to the Admin API.
+
+| authentication enabled | local API    | remote API    | auth settings                                     |
+|------------------------|--------------|---------------|---------------------------------------------------|
+| yes                    | [`admin_listen`] | [`admin_api_uri`] | [`admin_gui_auth`], [`enforce_rbac`], [`admin_gui_auth_conf`], [`admin_gui_session_conf`] |
+| no                     | [`admin_listen`] | [`admin_api_uri`] | n/a                                               |
+
+To enable authentication, configure the following properties:
+
+* [`admin_gui_auth`] set to the desired plugin
+* [`admin_gui_auth_conf`] (optional)
+* [`admin_gui_session_conf`] set to the desired configuration
+* [`enforce_rbac`] set to `on`
+
+{:.important}
+> **Important:** When Kong Manager authentication is enabled, RBAC must be turned
+on to enforce authorization rules. Otherwise, whoever can log in
+to Kong Manager can perform any operation available on the Admin API.
+
+## TLS Certificates
+
+By default, if Kong Manager’s URL is accessed over HTTPS _without_ a certificate issued by a CA, it will
+receive  a self-signed certificate that modern web browsers will not trust, preventing the application
+from accessing the Admin API.
+
+In order to serve Kong Manager over HTTPS,  use a trusted certificate authority to issue TLS certificates,
+and have the resulting `.crt` and `.key` files ready for the next step.
+
+1) Move `.crt` and `.key` files into the desired directory of the Kong node.
+
+2) Point [`admin_gui_ssl_cert`] and [`admin_gui_ssl_cert_key`] at the absolute paths of the certificate and key.
+
+```
+admin_gui_ssl_cert = /path/to/test.crt
+admin_gui_ssl_cert_key = /path/to/test.key
+```
+
+3) Ensure that `admin_gui_url` is prefixed with `https` to use TLS, e.g.,
+
+```
+admin_gui_url = https://test.com:8445
+```
+
+### Using `https://localhost`
+
+If serving Kong Manager on localhost, it may be preferable to use HTTP as the protocol. If also using RBAC,
+set `cookie_secure=false` in `admin_gui_session_conf`. The reason to use HTTP for `localhost` is that
+creating TLS certificates for `localhost` requires more effort and configuration, and there may not be any
+reason to use it. The adequate use cases for TLS are (1) when data is in transit between hosts, or (2)
+when testing an application with [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
+(which Kong Manager does not use).
+
+External CAs cannot provide a certificate since no one uniquely owns `localhost`, nor is it rooted in a top-level
+domain (e.g., `.com`, `.org`). Likewise, self-signed certificates will not be trusted in modern browsers. Instead,
+it is necessary to use a private CA that allows you to issue your own certificates. Also ensure that the SSL state
+is cleared from the browser after testing to prevent stale certificates from interfering with future access to
+`localhost`.
+
+
+[`admin_gui_auth`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_auth
+[`admin_gui_ssl_cert`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_ssl_cert
+[`admin_gui_ssl_cert_key`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_ssl_cert_key
+[`default_ports`]: /enterprise/{{page.kong_version}}/deployment/default-ports
+[`admin_api_uri`]: /enterprise/{{page.kong_version}}/property-reference/#admin_api_uri
+[`admin_gui_auth_conf`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_auth_conf
+[`enforce_rbac`]: /enterprise/{{page.kong_version}}/property-reference/#enforce_rbac
+[`admin_listen`]: /enterprise/{{page.kong_version}}/property-reference/#admin_listen
+[`admin_gui_session_conf`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_session_conf

--- a/app/gateway/2.6.x/configure/auth/kong-manager/oidc.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/oidc.md
@@ -1,0 +1,88 @@
+---
+title: Enable OIDC for Kong Manager
+badge: enterprise
+---
+
+### Introduction
+
+Kong Enterprise offers the ability to bind authentication for Kong
+Manager **Admins** to an organization's OpenID Connect Identity
+Provider using the
+**[OpenID Connect Plugin](/hub/kong-inc/openid-connect/)**.
+
+**Note**: by using the configuration below, it is unnecessary to
+manually enable the **Plugin**; the configuration alone will enable
+**OIDC** for Kong Manager.
+
+### Prerequisites
+
+The following is an example using Google as the IdP and serving Kong Manager
+from its default URL, `http://127.0.0.1:8002`.
+
+(The `admin_gui_auth_config` value must be valid JSON.)
+
+```
+enforce_rbac = on
+admin_gui_auth=openid-connect
+admin_gui_session_conf = { "secret":"set-your-string-here" }
+admin_gui_auth_conf={                                      \
+  "issuer": "https://accounts.google.com/",                \
+  "client_id": ["<ENTER_YOUR_CLIENT_ID>"],                 \
+  "client_secret": ["<ENTER_YOUR_CLIENT_SECRET_HERE>"],    \
+  "consumer_by": ["username","custom_id"],                 \
+  "ssl_verify": false,                                     \
+  "consumer_claim": ["email"],                             \
+  "leeway": 60,                                            \
+  "redirect_uri": ["http://localhost:8002"],                      \
+  "login_redirect_uri": ["http://localhost:8002"],                \
+  "logout_methods": ["GET", "DELETE"],                     \
+  "logout_query_arg": "logout",                            \
+  "logout_redirect_uri": ["http://localhost:8002"],               \
+  "scopes": ["openid","profile","email","offline_access"], \
+  "auth_methods": ["authorization_code"]                   \
+}
+```
+
+The **Sessions Plugin** requries a secret and is configured securely by default.
+* Under all circumstances, the `secret` must be manually set to a string.
+* If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
+* If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
+Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+
+Replace the entries surrounded by `<>` with values that are valid for your IdP.
+For example, Google credentials can be found here:
+https://console.cloud.google.com/projectselector/apis/credentials
+
+## Step 1
+
+Create an **Admin** that has a **username** matching the **email** returned from
+the Identity Provider upon successful login.
+
+```bash
+$ http POST :8001/admins username="<admin_email>" email="<admin_email>" Kong-Admin-Token:<RBAC_TOKEN>
+```
+
+For example, if a user has a Google email address, **hal9000@sky.net**:
+
+```bash
+$ http POST :8001/admins username="hal9000@sky.net" email="hal9000@sky.net" Kong-Admin-Token:<RBAC_TOKEN>
+```
+
+**Note:** The **email** entered for the **Admin** in the request is used to
+ensure the **Admin** receives an email invitation, whereas **username** is the
+attribute that the **Plugin** uses with the IdP.
+
+## Step 2
+
+Assign the new **Admin** at least one **Role** so they can log in and access
+Kong entities.
+
+```bash
+$ http POST :8001/admins/<admin_email>/roles roles="<role-name>"
+```
+
+For example, if we wanted to grant **hal9000@sky.net** the **Role** of **Super Admin**:
+
+```bash
+$ http POST :8001/admins/hal9000@sky.net/roles roles="super-admin"
+```

--- a/app/gateway/2.6.x/configure/auth/kong-manager/reset-password.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/reset-password.md
@@ -1,0 +1,61 @@
+---
+title: Reset Passwords and RBAC Tokens in Kong Manager
+badge: free
+---
+
+## Passwords and RBAC Tokens
+
+For authentication, Kong uses two different credentials for **Admins**:
+
+1. An **Admin** uses a **password** to log in to Kong Manager.
+2. An **Admin** uses an **RBAC token** to make requests to the Kong Admin API.
+
+If (and only if) using **Basic Authentication**, an Admin may reset their **password** from within Kong Manager. Since **LDAP** and **OIDC Authentication** imply that an organization stores and manages passwords outside of Kong, password reset is not possible with either type.
+
+Since a hash of each **RBAC token** is stored in Kong, then regardless of the Authentication option selected, an **Admin** may reset their **RBAC token** from within Kong Manager. Note that to support confidentiality, **RBAC tokens** are hashed and cannot be retrieved after they are created. If a user forgets the token, the only recourse is to reset it.
+
+## How to Reset a Forgotten Password in Kong Manager
+
+Prerequisites:
+
+* `enforce_rbac = on`
+* `admin_gui_auth = basic-auth`
+* SMTP is configured to send emails
+
+Steps:
+
+1. At the login page, click **Forgot Password** beneath the login field.
+2. Enter the email address associated with the account.
+3. Click the link from the email.
+4. Reset the password. Note that you will need to provide it again immediately after the reset is complete.
+5. Log in with the new password.
+
+## How to Reset a Password from within Kong Manager
+
+Prerequisites:
+
+* `enforce_rbac = on`
+* `admin_gui_auth = basic-auth`
+* [`admin_gui_session_conf` is configured](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/).
+* Already logged in to Kong Manager
+
+Steps:
+
+1. At the **top right corner**, after hovering over the **account name**, select **Profile**.
+2. In the **Reset Password** section, fill in the fields and click the **Reset Password** button.
+
+## How to Reset an RBAC Token in Kong Manager
+
+Prerequisites:
+
+* `enforce_rbac = on`
+* [`admin_gui_auth` is set](/enterprise/{{page.kong_version}}/kong-manager/security/#authentication-with-plugins).
+* [`admin_gui_session_conf` is configured](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/).
+* Already logged in to Kong Manager
+
+Steps:
+
+1. At the **top right corner**, after hovering over the **account name**, select **Profile**.
+2. In the **Reset RBAC Token** section at the bottom, click **Reset Token**.
+3. Type in a new token and click **Reset**.
+4. To copy the token, click the **Copy** button at the right.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/sessions.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/sessions.md
@@ -1,0 +1,104 @@
+---
+title: Sessions in Kong Manager
+badge: free
+---
+
+## How does the Sessions Plugin work in Kong Manager?
+
+When a user logs in to Kong Manager with their credentials, the Sessions Plugin
+will create a session cookie. The cookie is used for all subsequent requests and
+is valid to authenticate the user. The session has a limited duration and renews
+at a configurable interval, which helps prevent an attacker from obtaining and
+ using a stale cookie after the session has ended.
+
+The Session configuration is secure by default, which may
+[require alteration](#session-security) if using HTTP or different domains for
+the Admin API and Kong Manager. Even if an attacker were to obtain a stale
+cookie, it would not benefit them since the cookie is encrypted. The encrypted
+session data may be stored either in Kong or the cookie itself.
+
+## Configuration to Use the Sessions Plugin with Kong Manager
+
+To enable sessions authentication, configure the following:
+
+```
+enforce_rbac = on
+admin_gui_auth = <set to desired auth type>
+admin_gui_session_conf = {
+    "secret":"<SET_SECRET>",
+    "cookie_name":"<SET_COOKIE_NAME>",
+    "storage":"<SET_STORAGE>",
+    "cookie_lifetime":<NUMBER_OF_SECONDS_TO_LIVE>,
+    "cookie_renew":<NUMBER_OF_SECONDS_LEFT_TO_RENEW>
+    "cookie_secure":<SET_DEPENDING_ON_PROTOCOL>
+    "cookie_samesite":"<SET_DEPENDING_ON_DOMAIN>"
+}
+```
+
+* `"cookie_name":"<SET_COOKIE_NAME>"`: The name of the cookie
+  * For example, `"cookie_name":"kong_cookie"`
+* `"secret":"<SET_SECRET>"`: The secret used in keyed HMAC generation. Although
+  the **Session Plugin's** default is a random string, the `secret` _must_ be
+  manually set for use with Kong Manager since it must be the same across all
+  Kong workers/nodes.
+* `"storage":"<SET_STORAGE>"`: Where session data is stored. It is `"cookie"` by default, but may be more secure if set to `"kong"` since access to the database would be required.
+* `"cookie_lifetime":<NUMBER_OF_SECONDS_TO_LIVE>`: The duration (in seconds) that the session will remain open; 3600 by    default.
+* `"cookie_renew":<NUMBER_OF_SECONDS_LEFT_TO_RENEW>`: The duration (in seconds) of a session remaining at which point
+   the Plugin renews the session; 600 by default.
+* `"cookie_secure":<SET_DEPENDING_ON_PROTOCOL>`: `true` by default. See [Session Security](#session-security) for
+    exceptions.
+* `"cookie_samesite":"<SET_DEPENDING_ON_DOMAIN>"`: `"Strict"` by default. See [Session Security](#session-security) for
+    exceptions.
+
+
+{:.important}
+> **Important:** The following properties must **not** be altered from default for use with Kong Manager:*
+* `logout_methods`
+* `logout_query_arg`
+* `logout_post_arg`
+
+For detailed descriptions of each configuration property, learn more in the
+[Session Plugin documentation](/hub/kong-inc/session).
+
+## Session Security
+
+The Session configuration is secure by default, so the cookie uses the
+[Secure, HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies),
+and [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies)
+directives.
+
+The following properties must be altered depending on the protocol and domains in use:
+* If using HTTP instead of HTTPS: `"cookie_secure": false`
+* If using different domains for the Admin API and Kong Manager: `"cookie_samesite": "off"`
+
+{:.important}
+> **Important:** </strong>Sessions are not invalidated when a user logs out if `"storage": "cookie"` (the default) is used. In that case, the cookie is deleted client-side. Only when session data is stored server-side with `"storage": "kong"` set is the session actively invalidated.
+
+
+## Example Configurations
+
+If using HTTPS and hosting Kong Manager and the Admin API from the same domain,
+the following configuration could be used for Basic Auth:
+
+```
+enforce_rbac = on
+admin_gui_auth = basic-auth
+admin_gui_session_conf = {
+    "cookie_name":"$4m04$"
+    "secret":"change-this-secret"
+    "storage":"kong"
+}
+```
+
+In testing, if using HTTP, the following configuration could be used instead:
+
+```
+enforce_rbac = on
+admin_gui_auth = basic-auth
+admin_gui_session_conf = {
+    "cookie_name":"04tm34l"
+    "secret":"change-this-secret"
+    "storage":"kong"
+    "cookie_secure":false
+}
+```

--- a/app/gateway/2.6.x/configure/auth/kong-manager/super-admin.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/super-admin.md
@@ -1,0 +1,53 @@
+---
+title: Create a Super Admin
+badge: free
+---
+
+If you seeded a **Super Admin** at the time of running
+migrations by passing `KONG_PASSWORD`, you may log in to Kong Manager
+with the `kong_admin` username.
+
+Otherwise, if `enforce_rbac=off`, you may create your first
+**Super Admin** within Kong Manager itself.
+
+You may also use this guide to create additional **Super Admins** once
+you have an account and `enforce_rbac=on`.
+
+1. Go to the "Teams" tab in Kong Manager.
+
+2. Click "+ Invite Admin" and fill out the form.
+
+3. Give the user the `super-admin` role in the `default` workspace.
+
+4. Return to the "Organization" page, and in the "Invited" section,
+click the email address of the user in order to view them.
+
+5. Click "Generate Registration Link".
+
+6. Copy the link for later use after completing the account setup.
+
+{:.important}
+> **Important:** Kong Manager does not support entity-level RBAC. Run Kong
+Manager on a node where `enforce_rbac` is set to `on` or `off`, but not `both`.
+
+
+## How to Create Your First Super Admin Account Post Installation
+
+In the event that the default `kong_admin`, **Super Admin**, was not seeded
+during the initial database preparation step as defined in
+[Step 1 in How To Start Kong Enterprise Securely](/enterprise/{{page.kong_version}}/start-kong-securely/#step-1),
+the following steps outline how to create and enable a new Super Admin post
+installation.
+
+1. Follow the instructions outlined above to create a new **Super Admin** user
+account and generate a registration link.
+
+2. Before the link generated above can be used, RBAC and GUI Authentication must
+be enabled. Follow the instructions on
+[how to enable Basic Auth on Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/basic).
+
+3. Paste the URL in your browser and you will be asked to create a password for
+the newly defined **Super Admin** user on the Kong Manager.
+
+4. Go to the Kong Manager homepage and you will be prompted to login with the
+new ***Super Admin*** credentials.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
@@ -1,0 +1,113 @@
+---
+title: Configure Workspaces in Kong Manager
+badge: free
+---
+
+**Workspaces** enable an organization to segment traffic so that
+teams of **Admins** sharing the same Kong cluster are only able to
+interact with entities from their groups. Within a **Workspace**,
+it is possible to invite **Admins** to a particular team and to
+enforce **RBAC** with **Roles** and **Permissions** that further
+delimit the types of actions and entities available to an **Admin**.
+
+## Prerequisites
+
+* [`enforce_rbac = on`](/enterprise/{{page.kong_version}}/property-reference/#enforce_rbac)
+* Kong Enterprise has [started](/enterprise/{{page.kong_version}}/start-kong-securely)
+* Logged in to Kong Manager as a **Super Admin**
+
+## Default Workspace
+
+When the first **Super Admin** logs in, they begin in the **Workspace**
+named **default**. From here, they may invite **Admins** who are
+intended to be able to manage all other **Workspaces**, as well as
+the **Workspaces** themselves.
+
+## Navigating across Workspaces in Kong Manager
+
+To navigate between Workspaces from the **Overview** page, click on any
+Workspace displayed beneath the **Vitals** chart.
+
+The list of **Workspaces** may be rendered as cards or a table,
+depending on preference.
+
+![Workspace List](https://doc-assets.konghq.com/1.3/manager/kong-manager-workspaces-grid.png)
+
+
+## Creating New Workspaces
+
+This guide describes how to create **Workspaces** in Kong
+Manager. As an alternative, if a **Super Admin** wants to create
+a **Workspace** with the Admin API, it is possible to do so
+using the [`/workspaces/` route](/enterprise/{{page.kong_version}}/admin-api/workspaces/reference/#add-workspace).
+
+1. Log in as the **Super Admin**. On the **Workspaces** page, click the **New Workspace**
+button at the top right to see the **Create Workspace** form. Name and choose a
+color / icon for the new Workspace.
+
+    ![New Workspace Form](https://doc-assets.konghq.com/1.3/manager/workspaces/01-create-new-workspace.png)
+
+    Each **Workspace** name should be unique,
+    regardless of letter case. For example, naming one
+    **Workspace** "Payments" and another one "payments" will
+    create two different workspaces that appear identical.
+
+    Do not name Workspaces the same as these major routes in Kong
+    Manager:
+
+    ```
+    • Admins
+    • Certificates
+    • Consumers
+    • Plugins
+    • Portal
+    • Routes
+    • Services
+    • SNIs
+    • Upstreams
+    • Vitals
+    ```
+
+2. Click the "Create New Workspace" button. Upon creation, the application will
+navigate to the new Workspace's dashboard.
+
+    ![New Dashboard](https://doc-assets.konghq.com/1.3/manager/workspaces/02-workspace-dashboard.png)
+
+
+## Delete or Edit a Workspace
+
+To delete a Workspace, everything inside the
+Workspace must be deleted first. This includes default Roles on the "Admins"
+page.
+
+1. Within the Workspace, navigate to the "Dashboard" page.
+
+    ![Workspace Dashboard](https://doc-assets.konghq.com/1.3/manager/workspaces/02-workspace-dashboard.png)
+
+2. At the top right, click the "Settings" button.
+
+3. Edit or delete the Workspace.
+
+
+## Workspace Access
+
+If a **Role** does not have permission to access entire endpoints within
+a **Workspace**, the **Admin** assigned to that **Role** will not be
+able to see the related navigation links.
+
+To set up access:
+1. Open Kong Manager.
+2. On the left sidebar, click the **Admins** link in the
+**Security** section.
+
+  If the sidebar is collapsed, hover over
+  the **security badge icon** at the bottom and click the
+  **Admins** link.
+
+The **Admins** page displays a list of current **Admins** and
+**Roles**. Four default **Roles** specific to the new
+**Workspace** are already visible, and new **Roles** specific
+to the **Workspace** can be assigned from this page.
+
+For more information about **Admins** and **Roles**, see
+[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/).

--- a/app/gateway/2.6.x/configure/auth/oidc-mapping.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-mapping.md
@@ -1,0 +1,259 @@
+---
+title: OIDC Authenticated Group Mapping
+badge: enterprise
+---
+## Introduction
+
+Using Kong's OpenID Connect plugin (OIDC), you can map identity provider (IdP)
+groups to Kong roles. Adding a user to Kong in this way gives them access to
+Kong based on their group in the IdP.
+
+After starting {{site.base_gateway}} with the desired configuration, you can
+create new admins whose usernames match those in your IdP. Those
+users will then be able to accept invitations to join Kong Manager and log in
+with their IdP credentials.
+
+If an admin's group changes in the IdP, their Kong admin account's associated
+role also changes in {{site.base_gateway}} the next time they log in through Kong
+Manager. The mapping removes the task of manually managing access in
+{{site.base_gateway}}, as it makes the IdP the system of record.
+
+Here's how OIDC authenticaticated group mapping works:
+1. Create roles in {{site.base_gateway}} using either the Kong Admin API or Kong
+Manager.
+2. Create groups and associate roles with the groups.
+3. Configure the OIDC plugin to connect with your IdP.
+4. When users log in to Kong Manager, they get permissions based on the IdP
+ group(s) they belong to.
+
+## Prerequisites
+* An IdP with an authorization server and users with groups assigned
+* [{{site.ee_product_name}} installed and configured](/enterprise/{{page.kong_version}}/deployment/installation/overview)
+* Kong Manager enabled
+* RBAC enabled
+* (If using Kubernetes) [Helm](https://helm.sh/docs/intro/install/) installed
+
+## Create Kong Groups and Assign Roles
+
+<div class="alert alert-ee blue">
+<b>Note:</b> The following examples assume that you have RBAC enabled with
+Basic Auth and are transitioning to OpenID Connect.
+</div>
+
+{% navtabs %}
+{% navtab Kong Manager %}
+
+Create a group and assign a role to it:
+
+1. Open **Teams** from the top navigation.
+2. Click the **Groups** tab.
+3. Click **Create New Group**.
+4. Set the **Group Name** to match your IdP group.
+
+    **Note:** Group names are case-sensitive. Make sure to match your IdP
+    group name exactly.
+
+5. (Optional) In the **Comment** field, enter a description for the group.
+6. Click on **Add/Edit Roles**, then choose a workspace and a role.
+7. Save the role assignment, then click **Create**.
+
+Create an admin for the group:
+1. Open the **Teams** from the top navigation.
+2. Click the **Admins** tab.
+3. Click **Invite Admin**.
+4. Enter a username and email, and optionally a custom ID to make the admin
+easy for you to identify.
+
+    **Note**: Make sure the username exactly matches the admin's name in
+    your IdP.
+
+5. Ensure the **Enable RBAC token** checkbox is checked.
+6. Save the role assignment, then click **Invite Admin**.
+
+{% endnavtab %}
+{% navtab Kong Admin API %}
+
+1. Create a group, making sure the group `name` parameter matches your IdP group
+name:
+
+    ```sh
+    $ curl -X POST --url http://<admin-hostname>:8001/groups \
+      --header 'content-type: application/json' \
+      --header 'kong-admin-token: <yourtoken>' \
+      --data '{
+          "comment": "example group",      
+          "name": "examplegroup"      
+        }'
+    ```
+
+    **Note:** Group names are case-sensitive. Make sure to match your IdP group
+    name exactly.
+
+2. Assign a role to the group:
+
+    ```sh
+    $ curl -X POST --url http://<admin-hostname>:8001/groups/{group-id}/roles \
+      --header 'content-type: application/json' \
+      --header 'kong-admin-token: <yourtoken>' \
+      --data '{   
+          "rbac_role_id": "e948171e-699c-4035-9b74-2b2b576d9644",
+    	    "workspace_id": "236bfa99-cf09-4389-afa8-e2bd6da89fd3"
+        }'
+    ```
+
+    Where:
+    * [`rbac_role_id`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#list-roles):
+    UUID of the role you want to assign.
+    * [`workspace_id`](/enterprise/{{page.kong_version}}/admin-api/workspaces/reference/#list-workspaces):
+    UUID of the workspace to add the role to.
+
+3. Create an admin for the group:
+
+    ```sh
+    $ curl -X POST --url http://<admin-hostname>:8001/admins \
+      --header 'content-type: application/json' \
+      --header 'kong-admin-token: <yourtoken>' \
+      --data '{
+      "username": "<someusername>",
+      "custom_id": "<examplename>",
+      "email": "<your-email@company.com>",
+      "rbac_token_enabled": true
+    }'
+    ```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Notice how in the instructions above, you did not assign a role to your
+admin. The role will be matched with the role assigned to them in the IdP.
+
+## Apply OIDC Auth Mapping to Kong Gateway
+
+{% navtabs %}
+{% navtab Kubernetes with Helm %}
+
+1. Create a configuration file for the OIDC plugin and save it as
+`admin_gui_auth_conf`. For group mapping, you must include the
+`authenticated_groups_claim` parameter as part of this configuration.
+
+    For example, the configuration should look something like this:
+
+    ```json
+    {
+      "issuer": "<https://my-auth-url>",
+      "client_id": ["<someid>"],
+      "client_secret": ["<somesecret>"],
+      "consumer_by": ["username","custom_id"],
+      "ssl_verify": false,
+      "consumer_claim": ["sub"],
+      "leeway": 60,
+      "redirect_uri": ["<http://manager.admin-hostname.com>"],
+      "login_redirect_uri": ["<http://manager.admin-hostname.com>"],
+      "logout_methods": ["GET", "DELETE"],
+      "logout_query_arg": "logout",
+      "logout_redirect_uri": ["<http://manager.admin-hostname.com>"],
+      "scopes": ["openid","profile","email","offline_access"],
+      "authenticated_groups_claim": ["groups"],
+      "auth_methods": ["authorization_code"]
+    }
+    ```
+
+    For detailed descriptions of all the parameters used here, and many other
+    customization options, see the [OpenID Connect parameter reference](/hub/kong-inc/openid-connect/#configuration-parameters).
+
+2. Create a secret from the file you just created:
+
+    ```sh
+    $ kubectl create secret generic kong-idp-conf --from-file=admin_gui_auth_conf -n kong
+    ```
+
+3. Update the RBAC section of the deployment `values.yml` file with the
+following parameters:
+
+    ```yaml
+    rbac:
+      enabled: true
+      admin_gui_auth: openid-connect
+      session_conf_secret: kong-session-conf   
+      admin_gui_auth_conf_secret: kong-idp-conf
+    ```
+
+4. Using Helm, upgrade the deployment with your YAML filename:
+
+    ```sh
+    $ helm upgrade --install kong-ee kong/kong -f ./myvalues.yaml -n kong
+    ```
+{% endnavtab %}
+{% navtab Docker %}
+
+If you have a Docker installation, run the following command to set the needed
+environment variables and reload the {{site.base_gateway}} configuration.
+
+Substitute all variables in angled brackets (`< >`) with your own values:
+
+```sh
+$ echo "
+  KONG_ENFORCE_RBAC=on \
+  KONG_ADMIN_GUI_AUTH=openid-connect \
+  KONG_ADMIN_GUI_AUTH_CONF='{
+      \"issuer\": \"<https://my-auth-url>\",
+      \"client_id\": [\"<someid>\"],
+      \"client_secret\": [\"<somesecret>\"],
+      \"consumer_by\": [\"username\",\"custom_id\"],
+      \"ssl_verify\": false,
+      \"consumer_claim\": [\"sub\"],
+      \"leeway\": 60,
+      \"redirect_uri\": [\"<http://manager.admin-hostname.com>\"],
+      \"login_redirect_uri\": [\"<http://manager.admin-hostname.com>\"],
+      \"logout_methods\": [\"GET\", \"DELETE\"],
+      \"logout_query_arg\": \"logout\",
+      \"logout_redirect_uri\": [\"<http://manager.admin-hostname.com>\"],
+      \"scopes\": [\"openid\",\"profile\",\"email\",\"offline_access\"],
+      \"authenticated_groups_claim\": [\"groups\"],
+      \"auth_methods\": [\"authorization_code\"]
+    }' kong reload exit" | docker exec -i <kong-container-id> /bin/sh
+```
+
+Replace `<kong-container-id>` with the ID of your container.
+
+{% endnavtab %}
+{% navtab kong.conf %}
+
+1. Navigate to your `kong.conf` file.
+
+2. With RBAC enabled, add the `admin_gui_auth` and `admin_gui_auth_conf`
+properties to the file:
+
+    ```
+    enforce_rbac = on
+    admin_gui_auth = openid-connect
+    admin_gui_auth_conf = {
+        "issuer": "<https://my-auth-url>",
+        "client_id": ["<someid>"],
+        "client_secret": ["<somesecret>"],
+        "consumer_by": ["username","custom_id"],
+        "ssl_verify": false,
+        "consumer_claim": ["sub"],
+        "leeway": 60,
+        "redirect_uri": ["<http://manager.admin-hostname.com>"],
+        "login_redirect_uri": ["<http://manager.admin-hostname.com>"],
+        "logout_methods": ["GET", "DELETE"],
+        "logout_query_arg": "logout",
+        "logout_redirect_uri": ["<http://manager.admin-hostname.com>"],
+        "scopes": ["openid","profile","email","offline_access"],
+        "authenticated_groups_claim": ["groups"],
+        "auth_methods": ["authorization_code"]
+      }
+    ```
+
+    For detailed descriptions of all the parameters used here, and many other
+    customization options, see the [OpenID Connect parameter reference](/hub/kong-inc/openid-connect/#configuration-parameters).
+
+3. Restart {{site.base_gateway}} to apply the file.
+
+    ```sh
+    $ kong restart -c /path/to/kong.conf
+    ```
+
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
@@ -1,0 +1,91 @@
+---
+title: Invite an Admin
+badge: free
+---
+
+An **Admin** is any user in Kong Manager. They may access
+Kong entities within their assigned **Workspaces** based
+on the **Permissions** of their **Roles**.
+
+This guide describes how to invite an **Admin** in Kong
+Manager. As an alternative, if a **Super Admin** wants to
+invite an **Admin** with the Admin API, it is possible to
+do so using
+[`/admins`](/enterprise/{{page.kong_version}}/admin-api/admins/reference/#invite-an-admin).
+
+## Invite an Admin
+
+1. Navigate to the **Teams** page in Kong Manager
+
+2. From the **Admins** tab select **Invite Admin**
+
+3. Fill out the username and email address. When a new **Admin** receives an
+invitation, they will only be able to log in with that email address. Assign the appropriate **Role** and click **Invite User** to send the invitation.
+
+     **Super Admins** can invite users to multiple **Workspaces**, and
+    assign them any **Role** available within **Workspaces**, including **Roles** that exist by default (e.g. `super-admin`, `read-only`) and **Roles** with customized permissions.
+
+    The **Super Admin** can see all available roles across
+    **Workspaces** on the **Roles** tab of the **Organization** page.
+
+
+4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list.
+
+    By default, the registration link will expire after 259,200
+    seconds (3 days). This time frame can be configured with the `kong.conf`
+    file in `admin_invitation_expiry`.
+
+    If an email fails to send, either due to an incorrect email
+    address or an external error, it will be possible to resend an invitation.
+
+    If SMTP is not enabled or the invitation email fails to send,
+    it is possible for the Super Admin to copy and provide a registration link
+    directly.
+
+5. The newly invited **Admin** will have the ability to set a password. If the **Admin** ever forgets the password, it is possible for them to reset it through a recovery email.
+
+
+## Copy and Send a Registration Link
+
+If a mail server is not yet set up, it is still possible to invite Admins to register and log in.
+
+1. Invite an **Admin** as described in the section above.
+
+2. If the "View" link is clicked next to the invited Admin's name, a
+    `register_url` is displayed on the invitee's details page.
+
+    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
+
+3. Copy and directly send this link to the invited Admin so that they may set
+    up their credentials and log in.
+
+If `admin_gui_auth` is `ldap-auth-advanced`, credentials are not stored in Kong, and the Admin will be directed to log in.
+
+## How to Grant an Admin Access with LDAP
+
+1. Pick a user in the LDAP Directory that will be the Super Admin.
+
+2. Change the Super Admin’s username in Kong by making a `PATCH` request to
+`admins/kong_admin` and setting the value of `username` to the corresponding
+LDAP `attribute`.
+
+For example, if the LDAP user's attribute is `einstein`,
+the `PATCH` to `/admins/kong_admin` should have a `username` set to `einstein`.
+
+3. Log in to Kong Manager using the LDAP credentials associated with the Super
+Admin.
+
+4. Invite Admins from the "Admins" page in Kong Manager, ensuring that the
+`username` of each Admin is mapped to the `attribute` value set in the LDAP
+directory.
+
+    To enable the Admins to log in, it is still necessary
+    to assign a Role to them.
+
+5. Once an Admin has logged in successfully and accesses the Admin API using
+their LDAP credentials, they will be marked as “approved” on the "Admins" list
+in Kong Manager
+
+    The new Admins will still receive an email, but all
+    credentials will be handled through the LDAP server, not Kong Manager
+    or the Admin API.

--- a/app/gateway/2.6.x/configure/auth/rbac/add-role.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-role.md
@@ -1,0 +1,80 @@
+---
+title: Add a Role and Permissions
+badge: free
+---
+
+### Introduction
+
+**Roles** make it easy to logically group and apply the same
+set of **Permissions** to **Admins**. **Permissions** may be
+customized in detail, down to individual actions and endpoints.
+
+Kong Enterprise includes default **Roles** for standard
+use cases, e.g. inviting additional **Super Admins**,
+inviting **Admins** that may only `read` endpoints.
+
+This guide describes how to create a custom **Role** in Kong
+Manager for a unique use case. As an alternative, if a
+**Super Admin** wants to create a **Role** with the Admin API,
+it is possible to do so using
+[`/rbac/roles`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role).
+To add **Permissions** to the new **Role**, use
+[`/rbac/roles/{name_or_id}/endpoints`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-endpoint-permission)
+for endpoints or
+[`/rbac/roles/{name_or_id}/entities`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-entity-permission)
+for specific entities.
+
+### Prerequisites
+
+* [`enforce_rbac = on`](/enterprise/{{page.kong_version}}/property-reference/#enforce_rbac)
+* Kong Enterprise has [started](/enterprise/{{page.kong_version}}/start-kong-securely)
+* Logged in to Kong Manager as a **Super Admin**
+
+## Video Walkthrough
+
+<video width="100%" autoplay loop controls>
+ <source src="https://konghq.com/wp-content/uploads/2019/02/role-creation-ent-34.mov" type="video/mp4">
+ Your browser does not support the video tag.
+</video>
+
+## Step 1
+
+On the **Admins** page, to create a new **Role**, click the
+**Add Role** button at the top right of the list of **Roles**.
+
+## Step 2
+
+On the **Add Role** form, name the **Role** according to the
+**Permissions** you want to grant.
+
+![New Role naming](https://konghq.com/wp-content/uploads/2018/11/km-new-role.png)
+
+**Note:** It may be helpful for future reference to include
+a brief comment describing the reason for the **Permissions** or
+a summary of the **Role**.
+
+## Step 3
+
+Click the **Add Permissions** button and fill out the form. Add the endpoint **Permissions** by marking the appropriate checkbox.
+
+![New Role permissions](https://konghq.com/wp-content/uploads/2018/11/km-perms.png)
+
+## Step 4
+
+Click **Add Permission to Role** to see the permissions listed on the form.
+
+![New Role permissions list](https://konghq.com/wp-content/uploads/2018/11/km-perms-list.png)
+
+## Step 5
+
+To forbid access to certain endpoints, click **Add Permission**
+again and use the **negative** checkbox.
+
+![Negative permissions](https://konghq.com/wp-content/uploads/2018/11/km-negative-perms.png)
+
+## Step 6
+
+Submit the form and see the new **Role** appear on the
+**Admins** page.
+
+![Roles list](https://konghq.com/wp-content/uploads/2018/11/km-roles-list.png)

--- a/app/gateway/2.6.x/configure/auth/rbac/add-user.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-user.md
@@ -1,0 +1,62 @@
+---
+title: Create an RBAC User
+badge: free
+---
+
+#### Admins vs. RBAC Users
+
+|            | Admin API | Kong Manager |
+|------------|-----------|--------------|
+| Admins     |     ✔️     |       ✔️    |
+| RBAC Users |     ✔️     |       X     |
+
+
+An RBAC User has the ability to access the Kong Enterprise Admin API. The Permissions assigned to their Role will define the types of actions they can perform with various Admin API objects.
+
+An [Admin](/enterprise/{{page.kong_version}}/kong-manager/security/#what-can-admins-do-in-kong-manager), like an RBAC User, has the ability to access the Kong Enterprise Admin API. The Admin also has the ability log in to Kong Manager. Like an RBAC User, an Admin’s Role will determine the types of actions it can perform—except that they will also have the ability to benefit from Kong Manager’s interface and visualizations.
+
+If creating a *service account* for Kong Enterprise, e.g., for a machine as part of an automated process, then an RBAC User is adequate.
+
+If creating a *personal account* for Kong Enterprise, then Admin may be preferable since it also has access to Kong Manager.
+
+#### Prerequisites
+
+* Authentication and RBAC are enabled, following the
+[Getting Started](/enterprise/{{page.kong_version}}/start-kong-securely/#prerequisites)
+guide
+* [Logged in as the Super Admin](/enterprise/{{page.kong_version}}/start-kong-securely/#step-4)
+or a user that has `/admins` and `/rbac` read and write access.
+
+## How to Add an RBAC User in Kong Manager
+
+1. From the dashboard, click the **Teams** tab in the top navigation menu.
+
+2. On the **Teams** page, click the **RBAC Users** tab.
+
+3. Using the dropdown menu, select which **Workspace** the new user has access to.
+
+    >Note: The **Default Workspace** is global, meaning the RBAC User with access to default has access to entities across all other Workspaces. This Workspace assignment is useful for administrative and auditing accounts, but not for members of specific teams.
+
+4. Click the **Add New User** button to the right of the dropdown menu to open the registration form.
+
+5. In the **Add New User** registration form provide a Name, User Token, Comment, and Enablement
+
+    The name of the RBAC User must be globally unique, even if two users are in different Workspaces, and it cannot have the same as an Admin account.
+
+    These naming conventions are important if using OIDC, LDAP, or another external method of identity and access management.
+
+    The RBAC User account is enabled by default, if you want the RBAC User account to start in a disabled state and enable it later, uncheck the box.
+
+6. Click the **Add User Roles** button in the **Role(s) per workspace** section. Select the Role (or Roles) desired for the new RBAC User.
+
+    If the RBAC User has no Roles assigned, it will not have permission to access any objects.
+
+    An RBAC User’s Role assignments may be altered later if needed.
+
+    The Roles can only belong to one Workspace, as selected in Step 3.
+
+    To provide an RBAC User with access to objects in multiple Workspaces, see Step 3.
+
+7. Click **Create User** to complete the user registration.
+
+    The page will automatically redirect back to the **Teams** page, where the new user is listed.

--- a/app/gateway/2.6.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/index.md
@@ -1,0 +1,56 @@
+---
+title: RBAC in Kong Manager
+badge: free
+---
+
+### Introduction to RBAC in Kong Manager
+
+In addition to authenticating **Admins** and segmenting **Workspaces**,
+Kong Enterprise has the ability to enforce Role-Based Access Control
+(RBAC) for all resources with the use of **Roles** assigned to **Admins**.
+
+As the **Super Admin** (or any **Role** with **read** and **write**
+access to the `/admins` and `/rbac` endpoints), it is possible to
+create new **Roles** and customize **Permissions**.
+
+In Kong Manager, RBAC affects how **Admins** are able to navigate
+through the application.
+
+### Default Roles
+
+Kong includes Role-Based Access Control (RBAC). Every **Admin** using Kong Manager
+will need an assigned **Role** based on the resources they have **Permission** to access.
+
+When a **Super Admin** starts Kong for the first time, the `default` **Workspace** will
+include three default **Roles**: `read-only`, `admin`, and `super-admin`. The three
+**Roles** have **Permissions** related to every **Workspace** in the cluster.
+
+Similarly, if a **Role** is confined to certain **Workspaces**, the **Admin** assigned to it
+will not be able to see either the overview or links to other **Workspaces**.
+
+If a **Role** does not have **Permission** to access entire endpoints,
+the **Admin** assigned to the **Role** will not be able to see the related navigation links.
+
+{:.important}
+> **Important:** Although a default **Admin** has full permissions with every
+endpoint in Kong, only a **Super Admin** has the ability to assign and modify RBAC **Permissions**. An **Admin** is not able to modify their own **Permissions** or delimit a **Super Admin's** **Permissions**.
+
+### RBAC in Workspaces
+
+RBAC **Roles** and **Permissions** will be specific to a **Workspace** if they are assigned
+from within one. For example, if there are two **Workspaces**, **Payments** and
+**Deliveries**, an **Admin** created in **Payments** will not have access to any
+endpoints in **Deliveries**.
+
+When a **Super Admin** creates a new **Workspace**, there are three default **Roles** that
+mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
+`workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
+`workspace-portal-admin`.
+
+These roles can be viewed in the **Teams** tab under **Roles**
+
+![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
+
+**IMPORTANT**: Any Role assigned in the **Default Workspace** will have
+**Permissions** applied to all subsequently created **Workspaces**. A **Super Admin**
+in `default` has RBAC **Permissions** across all **Workspaces**.

--- a/app/gateway/2.6.x/configure/auth/service-directory-mapping.md
+++ b/app/gateway/2.6.x/configure/auth/service-directory-mapping.md
@@ -1,0 +1,164 @@
+---
+title: Mapping LDAP Service Directory Groups to Kong Roles
+badge: enterprise
+---
+
+### Introduction
+
+Service Directory Mapping allows organizations to use their LDAP Directory for authentication and authorization in Kong Enterprise.
+
+After starting Kong Enterprise with the desired configuration, you can create new Admins whose usernames match those in your LDAP directory. Those users will then be able to accept invitations to join Kong Manager and log in with their LDAP credentials.
+
+How Service Directory Mapping works in Kong:
+* Roles are created in Kong Enterprise using the Admin API or Kong Manager.
+* Groups are created and roles are associated with the groups.
+* When users log in to Kong Manager, they get permissions based on the group(s) they belong to.
+
+For example, if a User's Group changes in the Service Directory, their Kong Admin account's associated Role also changes in Kong Enterprise the next time they log in to Kong Manager. The mapping removes the task of manually managing access in Kong Enterprise, as it makes the Service Directory the system of record.
+
+### Prerequisites
+
+* Kong Enterprise installed and configured
+* Kong Manager access
+* A local LDAP directory
+
+### Configure Service Directory Mapping
+
+Configure Service Directory Mapping to use your LDAP Directory for authentication and authorization.
+
+### Step 1: Start Kong Enterprise
+
+From a terminal window, enter:
+
+```
+$ kong start [-c /path/to/kong/conf]
+```
+
+### Step 2: Enable LDAP Authentication and enforce RBAC
+
+To enable LDAP Authentication and enforce RBAC for Kong Manager, configure Kong with the following properties:
+
+```
+admin_gui_auth = ldap-auth-advanced
+enforce_rbac = on
+```
+
+**Note**: When enabling LDAP Authentication in this step, you are enabling and configuring the LDAP Authentication Advanced Plugin for Kong Manager. No other configuration for the plugin is needed.
+
+### Step 3: Configure the Sessions plugin
+
+Configure the Sessions Plugin for Kong Manager:
+
+```
+admin_gui_session_conf = { "secret":"set-your-string-here" }
+```
+
+>Note: The **Sessions Plugin** requires a **secret** and is configured securely by default:
+
+* Under all circumstances, the secret must be manually set to a string.
+*  If using HTTP instead of HTTPS, cookie_secure must be manually set to false.
+*  If using different domains for the Admin API and Kong Manager, cookie_samesite must be set to off. Learn more about these properties in [_Session Security in Kong Manager_](https://docs.konghq.com/enterprise/0.36-x/kong-manager/authentication/sessions/#session-security), and see [_example configurations_](https://docs.konghq.com/enterprise/0.36-x/kong-manager/authentication/sessions/#example-configurations).
+
+### Step 4: Configure LDAP Authentication for Kong Manager
+
+Configure LDAP Authentication for Kong Manager with the following properties. Note the attribute variables are defined below:
+
+```
+admin_gui_auth_conf = {
+ "anonymous":"", \
+ "attribute":"<ENTER_YOUR_ATTRIBUTE_HERE>", \
+ "bind_dn":"<ENTER_YOUR_BIND_DN_HERE>", \
+ "base_dn":"<ENTER_YOUR_BASE_DN_HERE>", \
+ "cache_ttl": 2, \
+ "header_type":"Basic", \
+ "keepalive":60000, \
+ "ldap_host":"<ENTER_YOUR_LDAP_HOST_HERE>", \
+ "ldap_password":"<ENTER_YOUR_LDAP_PASSWORD_HERE>", \
+ "ldap_port":389, \
+ "start_tls":false, \
+ "timeout":10000, \
+ "verify_ldap_host":true, \
+ "consumer_by":["username", "custom_id"], \
+ "group_base_dn":"<ENTER_YOUR_GROUP_BASE_DN_HERE>",
+ "group_name_attribute":"<ENTER_YOUR_GROUP_NAME_ATTRIBUTE_HERE>",
+ "group_member_attribute":"<ENTER_YOUR_GROUP_MEMBER_ATTRIBUTE_HERE>",
+}
+```
+
+* `attribute`:`<ENTER_YOUR_ATTRIBUTE_HERE>`: The attribute used to identify LDAP users
+    * For example, to map LDAP users to admins by their username, `attribute":"uid`
+* `bind_dn`:`<ENTER_YOUR_BIND_DN_HERE>`: LDAP Bind DN (Distinguished Name)
+    * Used to perform LDAP search of user. This bind_dn should have permissions to search for the user being authenticated.
+    * For example, `uid=einstein,ou=scientists,dc=ldap,dc=com`
+* `base_dn`:`<ENTER_YOUR_BASE_DN_HERE>`: LDAP Base DN (Distinguished Name)
+    * For example, `ou=scientists,dc=ldap,dc=com`
+* `ldap_host`:`<ENTER_YOUR_LDAP_HOST_HERE>`: LDAP host domain.
+    * For example, `ec2-XX-XXX-XX-XXX.compute-1.amazonaws.com`
+* `ldap_port`: The default LDAP port is 389. 636 is the port required for SSL LDAP and AD.
+   If ldaps is configured, you must use port 636. For more complex Active Directory (AD) environments,
+   instead of Domain Controller and port 389, consider using a Global Catalog host and port, which is port 3268 by default.    
+* `ldap_password`:`<ENTER_YOUR_LDAP_PASSWORD_HERE>`: LDAP password
+    * *Important*: As with any configuration property, sensitive information may be set as an environment variable instead of being written directly in the configuration file.
+* `group_base_dn`:`<ENTER_YOUR_BASE_DN_HERE>`: Sets a distinguished name for the entry where LDAP searches for groups begin. The default is the value from `conf.base_dn`.
+* `group_name_attribute`: `<ENTER_YOUR_GROUP_NAME_ATTRIBUTE_HERE>`: Sets the attribute holding the name of a group, typically called `name` (in Active Directory) or `cn` (in OpenLDAP). The default is the value from `conf.attribute`.
+* `group_member_attribute`:`<ENTER_YOUR_GROUP_MEMBER_ATTRIBUTE_HERE>`: Sets the attribute holding the members of the LDAP group. The default is `memberOf`.
+
+### Define Roles with Permissions
+
+Define **Roles** with **Permissions** in Kong Enterprise, using the Admin API's [**_RBAC endpoints_**](https://docs.konghq.com/enterprise/latest/admin-api/rbac/reference/#update-or-create-a-role) or using Kong Manager's **Teams > [Admins tab](https://docs.konghq.com/enterprise/latest/kong-manager/administration/admins/invite/#using-the-organization-page-to-manage-users)**. You must manually define which Kong **Roles** correspond to each of the Service Directory's **Groups** using either of the following:
+
+In Kong Manager's **Directory Mapping** section. Go to **Teams > Groups** tab.
+With the Admin API's **Directory Mapping** endpoints.
+
+Kong Enterprise will not write to the Service Directory, for example, a Kong Enterprise Admin cannot create **Users** or **Groups** in the directory. You must create **Users** and **Groups** independently before mapping them to Kong Enterprise.
+
+### User-Admin Mapping
+
+To map a Service Directory **User** to a Kong **Admin**, you must configure the **Admin's** username as the value of the **User's** name from their LDAP Distinguished Name (DN) corresponding the attribute configured in admin_gui_auth_conf. Creating an **Admin** account in [_Kong Manager_](https://docs.konghq.com/enterprise/latest/kong-manager/administration/admins/add-admin/) or using the [_Admin API_](https://docs.konghq.com/enterprise/latest/admin-api/admins/reference/#invite-an-admin).
+
+For instructions on how to pair the bootstrapped **Super Admin** with a **Directory User**, see [_How to Set Up a Service Directory User as the First Super Admin_](/enterprise/{{page.kong_version}}/kong-manager/service-directory-mapping/#set-up-a-directory-user-as-the-first-super-admin).
+
+If you already have **Admins** with assigned **Roles** and want to use **Group** mapping instead, it is necessary to first remove all of their Roles. The Service Directory will serve as the system of record for **User** privileges. Assigned **Roles** will affect a user's privileges in addition to any roles mapped from **Groups.**
+
+### Group-Role Assignment
+
+Using Service Directory Mapping, **Groups** to **Roles** are mapped. When a user logs in, they are identified with their **Admin** username and then authenticated with the matching **User** credentials in the** Service Directory**. The Groups in the Service Directory are then automatically matched to the associated Roles that the organization has defined.
+
+#### Example
+
+1. Wayne Enterprises maps the Service Directory Group, T1-Mgmt, to the Kong Role super-admin.
+2. Wayne Enterprises maps a Service Directory User, named bruce-wayne, to a Kong Admin account with the same name, bruce-wayne.
+3. The User, bruce-wayne, is assigned to the Group T1-Mgmt in the LDAP Directory.
+
+
+When bruce-wayne logs in as an Admin to Kong Manager, they will automatically have the Role of super-admin as a result of the mapping.
+
+If Wayne Enterprises decides to revoke bruce-wayne's privileges by removing their assignment to T1-Mgmt, they will no longer have the super-admin Role when they attempt to log in.
+
+### Set Up a Directory User as the First Super Admin
+
+**Important**: Setting up a Directory User as the first Super Admin is recommended by Kong.
+
+
+The following is an example of setting up a Directory User as the first Super Admin.
+The example shows an attribute is configured with a unique identifier (UID), and the Directory User you want to make the Super Admin has a distinguished name (DN) entry of UID=bruce-wayne:
+
+```
+HTTPie
+$ http PATCH :8001/admins/kong_admin username="bruce-wayne"
+Kong-Admin-Token:<RBAC_TOKEN>
+cURL
+$ curl --request 'PATCH' --header 'Kong-Admin-Token: <RBAC_TOKEN>' --header
+'Content-Type: application/json' --data '{"username":"bruce-wayne"}'
+'localhost:8001/admins/kong_admin'
+```
+
+This User will be able to log in, but until you map a Group belonging to bruce-wayne to a Role, the User will only use the Directory for authentication. Once you map the super-admin Role to a Group that bruce-wayne is in, then you can delete the super-admin Role from the bruce-wayne Admin. Note the group you pick needs to be “super” in your directory, otherwise as other admins log in with a generic group, for example the “employee” group, they will also become super-admins.
+
+**Important**: If you delete the super-admin Role from your only Admin, and have not yet mapped the super-admin Role to a Group that Admin belongs to, then you will not be able to log in to Kong Manager.
+
+Alternatives:
+
+* Start Kong with RBAC turned off, map a Group to the super-admin Role, and then create an Admin to correspond to a User belonging to that Group. Doing so ensures that the Super Admin's privileges are entirely tied to the Directory Group, whereas bootstrapping a Super Admin only uses the Directory for authentication.
+
+Create all Admin accounts for matching Directory Users and ensure that their existing Groups map to appropriate Roles before enforcing RBAC.

--- a/app/gateway/2.6.x/index.md
+++ b/app/gateway/2.6.x/index.md
@@ -51,7 +51,14 @@ This sets the foundations for a modular architecture, where Lua scripts (referre
 ### Kong Manager
 {:.badge .free}
 
-Kong Manager is the Graphical User Interface (GUI) for {{site.base_gateway}}. It uses the Kong Admin API under the hood to administer and control {{site.ce_product_name}}. Use Kong Manager to organize teams, adjust policies, and monitor performance with just a few clicks. Group your teams, services, plugins, consumer management, and more exactly how you want them. Create new routes and services, activate or deactivate plugins in seconds.
+Kong Manager is the graphical user interface (GUI) for {{site.base_gateway}}. It uses the Kong Admin API under the hood to administer and control {{site.ce_product_name}}.
+
+Here are some of the things you can do with Kong Manager:
+
+* Create new Routes and Services.
+* Activate or deactivate plugins with a couple of clicks.
+* Group your teams, services, plugins, consumer management, and everything else exactly how you want them.
+* Monitor performance: visualize cluster-wide, workspace-level, or even object-level health using intuitive, customizable dashboards.
 
 ### Kong plugins
 


### PR DESCRIPTION
### Summary
* Audited [Kong Manager](https://docs.konghq.com/enterprise/2.5.x/kong-manager/overview/) doc and moved what was relevant
  * Combined duplicate topics: roles, users, workspaces, admins
  * Didn't move over topics that just exist for redirects (empty topics, there were a few)
  * Didn't move over topics from the [How-tos section ](https://docs.konghq.com/enterprise/2.5.x/kong-manager/add-service/) of the docs; these are duplicates of the getting started guide (in fact, they're what's left of a previous version of the getting started guide)
  * Moved everything into "configure"
  * Minor cleanup in topics to fix some broken/extraneous warnings
  * Moved Kong Manager overview topic contents into the introduction for the whole doc set
  * Labelled RBAC topics as "FREE"; labelled all others as "ENTERPRISE", as they use Enterprise plugins
 
* Added a FREE badge option for page titles

### Reason
Single-sourcing

### Testing
Tested locally.
