### PR TITLE
[DOCU-1964] Rework dropdown menus

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -32,12 +32,22 @@ jQuery(function () {
     activeNav.parents(".accordion-item").addClass("active");
   };
 
+// Function to close menus on pressing the "Escape" key
+  function closeDropdownOnEscape () {
+    if (event.key === 'Escape') {
+      $('#module-list').removeClass('open');
+      $('#version-list').removeClass('open');
+    }
+  };
+
   // MODULE DROPDOWN: dropdown menu functionality (handles main product dropdown)
-  $("#module-dropdown").on("click", function (e) {
+
+  // Actions that occur on click and escape button press
+  $('#module-dropdown').on('click', function (e) {
     e.preventDefault();
     e.stopPropagation();
 
-    $("#module-list").toggleClass("open");
+    $('#module-list').toggleClass('open');
 
     $(document).one('click', function closeMenu(e) {
       if ($('#module-list').has(e.target).length === 0) {
@@ -45,15 +55,49 @@ jQuery(function () {
       } else {
         $(document).one('click', closeMenu);
       }
+    }).closeDropdownOnEscape();
+  });
+
+  // Enables tabbing through the module menu
+  $('#module-dropdown').on('keypress keydown', function(e) {
+    if(e.keyCode == 13) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    $('#module-list')
+      .toggleClass('open')
+      .setAttribute('aria-hidden', 'false')
+      .setAttribute('aria-expanded', 'true');
+    return false;
+    }
+   // if user doesn't open product submenu, move focus to version menu item
+    let submenu = $('#module-list')
+    if(!submenu.hasClass('open')) {
+      $('#version-list').focus();
+    }
+
+    // close docs dropdown menu when tabbing to the version dropdown
+    $('#version-dropdown').on('focus', function(e) {
+      $('#module-list').removeClass('open');
+    });
+
+    // close product or version dropdown menu when tabbing on the first navigation menu item
+    $('.accordion-link').on('focus', function(e) {
+      $('#module-list').removeClass('open');
+      $('#version-list').removeClass('open');
+    });
+
+    $(document).on('keypress keydown', function(e) {
+        closeDropdownOnEscape()
     });
   });
 
   // VERSION DROPDOWN: dropdown menu functionality (handles plugin detail page, lua, and main versions dropdown)
-  $("#version-dropdown").on("click", function (e) {
+  $('#version-dropdown').on('click', function (e) {
     e.preventDefault();
     e.stopPropagation();
 
-    $("#version-list").toggleClass("open");
+    $('#version-list').toggleClass('open');
 
     $(document).one('click', function closeMenu(e) {
       if ($('#version-list').has(e.target).length === 0) {
@@ -61,24 +105,41 @@ jQuery(function () {
       } else {
         $(document).one('click', closeMenu);
       }
+    }).closeDropdownOnEscape();
+  });
+
+  // Enables tabbing through the version menu
+  $('#version-dropdown').on('keypress keydown', function(e) {
+    if(e.keyCode == 13) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    $('#version-list')
+      .toggleClass('open')
+      .setAttribute('aria-hidden', 'false')
+      .setAttribute('aria-expanded', 'true');
+    return false;
+    }
+    $(document).on('keypress keydown', function(e) {
+      closeDropdownOnEscape ()
     });
   });
 
-    // COMPAT DROPDOWN: dropdown menu functionality (handles /konnect-platform/compatibility dropdown)
-    $("#compat-dropdown").on("click", function(e) {
-      e.preventDefault();
-      e.stopPropagation();
+  // COMPAT DROPDOWN: dropdown menu functionality (handles /konnect-platform/compatibility dropdown)
+  $("#compat-dropdown").on("click", function(e) {
+    e.preventDefault();
+    e.stopPropagation();
 
-      $("#compat-list").toggleClass("open");
+    $("#compat-list").toggleClass("open");
 
-      $(document).one('click', function closeMenu (e){
-          if($('#compat-list').has(e.target).length === 0){
-              $('#compat-list').removeClass('open');
-          } else {
-              $(document).one('click', closeMenu);
-          }
-      });
+    $(document).one('click', function closeMenu (e){
+        if($('#compat-list').has(e.target).length === 0){
+            $('#compat-list').removeClass('open');
+        } else {
+            $(document).one('click', closeMenu);
+        }
     });
+  });
 
   // COOKIE MODAL: Hide banner on "I accept" and set cookie
   $(".cookie-policy-accept").on("click", function (e) {

--- a/app/_assets/stylesheets/dropdown.less
+++ b/app/_assets/stylesheets/dropdown.less
@@ -88,6 +88,18 @@
     }
   }
 
+  .dropdown-menu {
+    li {
+      a {
+        &:focus-visible {
+          color: #1155cb;
+          outline: 2px solid #1155cb;
+          border-radius: 3px;
+        }
+      }
+    }
+  }
+
   &.no-right-border {
     button {
       border-right-width: 0;
@@ -134,12 +146,6 @@
 
         &:hover, &.active {
           color: #1155cb;
-        }
-
-        &:focus {
-          color: #1155cb;
-          outline: 2px solid #1155cb;
-          border-radius: 3px;
         }
 
         > ul {

--- a/app/_assets/stylesheets/dropdown.less
+++ b/app/_assets/stylesheets/dropdown.less
@@ -34,11 +34,31 @@
     right: 0;
     left: auto;
   }
+  hr {
+    width: 90%;
+    margin: 15px;
+  }
 
   > li {
     margin: 0;
     &:not(:last-child) {
       padding-bottom: 4px;
+
+      > ul {
+        list-style: none;
+        margin: 5px;
+        margin-top: 0;
+
+        a, span {
+          font-weight: 400;
+          float: left;
+          border-left: 2px solid transparent;
+        }
+
+        li {
+          margin: 0;
+        }
+      }
     }
 
     > a, span {
@@ -60,7 +80,7 @@
 }
 
 .versions-dropdown, .docsets-dropdown {
-  li.active  {
+  li.active, li > ul > li.active  {
     a {
       color: @blue-text;
       font-weight: 600;
@@ -115,6 +135,16 @@
         &:hover, &.active {
           color: #1155cb;
         }
+
+        &:focus {
+          color: #1155cb;
+          outline: 2px solid #1155cb;
+          border-radius: 3px;
+        }
+
+        > ul {
+          list-style: none
+        }
       }
     }
 
@@ -125,15 +155,6 @@
 
   @media screen and (max-width: 400px) {
     min-width: 100%;
-  }
-}
-
-.dropdown-menu > .active > a {
-  &,
-  &:hover,
-  &:focus {
-    text-decoration: none;
-    outline: 0;
   }
 }
 

--- a/app/_assets/stylesheets/header-v2.less
+++ b/app/_assets/stylesheets/header-v2.less
@@ -9,6 +9,13 @@ header.navbar-v2 {
   z-index: 100;
   padding: 0 24px;
 
+  hr {
+    width: 90%;
+    margin-top: 8px;
+    margin-bottom: 15px;
+  }
+
+
   a.skip-main {
     left:-999px;
     position:absolute;
@@ -17,6 +24,9 @@ header.navbar-v2 {
     height:1px;
     overflow:hidden;
     z-index:-999;
+    font-weight: 400;
+    float: left;
+    border-left: 2px solid transparent;
   }
 
   a.skip-main:focus, a.skip-main:active {
@@ -162,6 +172,10 @@ header.navbar-v2 {
         padding: 18px 0;
         white-space: nowrap;
         cursor: pointer;
+        font-weight: 400;
+        color: #043558;
+        font: 500 16px/24px Roboto;
+        transition: color .25s;
 
         a:hover {
           text-decoration: underline;

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -387,6 +387,12 @@
       border-color: @gray-border;
       background-color: @gray-background;
 
+      &:focus-visible {
+        color: #1155cb;
+        outline: 2px solid #1155cb;
+        border-radius: 3px;
+      }
+
       em {
         font-style: normal;
       }

--- a/app/_includes/accordion-item.html
+++ b/app/_includes/accordion-item.html
@@ -8,7 +8,7 @@
     <img src="{{ include.icon }}" alt="">
     {% endif %}
     {% if include.url %}
-    <a href="{{ include.url }}">{{ include.label }}</a>
+    <a href="{{ include.url }}" class="accordion-link" role="menuitem" tabindex="0">{{ include.label }}</a>
     {% else %}
     {{ include.label }}
     {% endif %}

--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -21,46 +21,39 @@
         </span>
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu dropdown-menu-right" id="module-list" role="menu" aria-labelledby="module-dropdown">
-        <div class="dropdown-submenu-title">Kong Konnect Platform</div>
-        <li {% if include.edition == 'konnect_platform' %} class="active" {% endif %}>
-          <a href="/konnect-platform/" class="{% if include.edition == 'konnect_platform' %}active{% endif %}">{{site.konnect_product_name}} Platform</a>
+      <ul class="dropdown-menu dropdown-menu-right" id="module-list" role="menu" aria-labelledby="module-dropdown" >
+
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'gateway' or include.edition == 'gateway-oss' or include.edition == 'enterprise' %} class="active" {% endif %}>
+          <a href="/gateway/" class="{% if include.edition == 'gateway' %}active{% endif %}">Kong Gateway</a>
         </li>
-        <li {% if include.edition == 'konnect' %} class="active" {% endif %}>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect' %} class="active" {% endif %}>
           <a href="/konnect/" class="{% if include.edition == 'konnect' %}active{% endif %}">Konnect Cloud</a>
         </li>
-        <li {% if include.edition == 'enterprise' %} class="active" {% endif %}>
-          <a href="/enterprise/" class="{% if include.edition == 'enterprise' %}active{% endif %}">Kong Gateway (Enterprise)</a>
-        </li>
-        <li {% if include.edition == 'mesh' %} class="active" {% endif %}>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'mesh' %} class="active" {% endif %}>
           <a href="/mesh/" class="{% if include.edition == 'mesh' %}active{% endif %}">Kong Mesh</a>
         </li>
-        <li>
-          <a href="/hub/">Plugin Hub</a>
-        </li>
-        <div class="dropdown-submenu-title">Open Source</div>
-        <li {% if include.edition == 'gateway-oss' %} class="active" {% endif %}>
-          <a href="/gateway-oss/" class="{% if include.edition == 'gateway-oss' %}active{% endif %}">Kong Gateway (OSS)</a>
-        </li>
-        <li {% if include.edition == 'deck' %} class="active" {% endif %}>
-          <a href="/deck/" class="{% if include.edition == 'deck' %}active{% endif %}">decK</a>
-        </li>
-        <li {% if include.edition == 'kubernetes-ingress-controller' %} class="active" {% endif %}>
-          <a href="/kubernetes-ingress-controller/" class="{% if include.edition == 'kubernetes-ingress-controller' %}active{% endif %}">Kubernetes Ingress Controller</a>
+        <li role="menuitem" tabindex="-1">
+          <a href="https://kuma.io/docs/" target="_blank">Kuma</a>
         </li>
         <li>
           <a href="https://support.insomnia.rest/" target="_blank">Insomnia</a>
         </li>
-        <li>
-          <a href="https://kuma.io/docs/" target="_blank">Kuma</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'deck' %} class="active" {% endif %}>
+          <a href="/deck/" class="{% if include.edition == 'deck' %}active{% endif %}">decK</a>
         </li>
-        <div class="dropdown-submenu-title">Contribute to the docs</div>
-        <li {% if include.edition == 'contributing' %} class="active" {% endif %}>
-          <a href="/contributing/" class="{% if include.edition == 'contributing' %}active{% endif %}">Contribution guidelines</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'kubernetes-ingress-controller' %} class="active" {% endif %}>
+          <a href="/kubernetes-ingress-controller/" class="{% if include.edition == 'kubernetes-ingress-controller' %}active{% endif %}">Kubernetes Ingress Controller</a>
         </li>
-        <div class="dropdown-submenu-title">One Gateway doc (temporary location)</div>
-        <li {% if page.edition == 'gateway' %} class="active" {% endif %}>
-          <a href="/gateway/" class="{% if page.edition == 'gateway' %}active{% endif %}">Kong Gateway</a>
+        <li role="menuitem" tabindex="-1">
+          <a href="/hub/">Plugin Hub</a>
+        </li>
+        <hr>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect_platform' %} class="active" {% endif %}>
+          <a href="/konnect-platform/" class="{% if include.edition == 'konnect_platform' %}active{% endif %}">Common documentation</a>
+        </li>
+        <hr>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'contributing' %} class="active" {% endif %}>
+          <a href="/contributing/" class="{% if include.edition == 'contributing' %}active{% endif %}">Docs contribution guidelines</a>
         </li>
       </ul>
     </div>
@@ -76,7 +69,7 @@
         </span>
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu dropdown-menu-right" id="version-list" role="menu" aria-labelledby="version-dropdown">
+      <ul class="dropdown-menu dropdown-menu-right" id="version-list" role="menu" aria-labelledby="version-dropdown" tabindex="0">
           {% for ver in include.kong_versions reversed %}
           {% assign version_page_url = include.url | replace: include.kong_version, ver.release %}
           {% capture version_page_exists %}{% page_exists {{version_page_url}} %}{% endcapture %}

--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -5,7 +5,7 @@
 
   <div class="sidebar-title-container">
     <div class="docsets-dropdown dropdown">
-      <button class="dropdown-button" id="module-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button class="dropdown-button" id="module-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
         <span>
           {% if include.edition == 'enterprise' %}{{site.ee_product_name}}
           {% elsif include.edition == 'konnect' %}{{site.konnect_saas}}
@@ -21,16 +21,16 @@
         </span>
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu dropdown-menu-right" id="module-list" role="menu" aria-labelledby="module-dropdown" >
+      <ul class="dropdown-menu dropdown-menu-right with-submenu" id="module-list" role="menu" aria-labelledby="module-dropdown" aria-hidden="true">
 
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'gateway' or include.edition == 'gateway-oss' or include.edition == 'enterprise' %} class="active" {% endif %}>
-          <a href="/gateway/" class="{% if include.edition == 'gateway' %}active{% endif %}">Kong Gateway</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'gateway' or include.edition == 'gateway-oss' or include.edition == 'enterprise' %}class="active"{% endif %}>
+          <a href="/gateway/" {% if include.edition == 'gateway' %}class="active"{% endif %}>Kong Gateway</a>
         </li>
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect' %} class="active" {% endif %}>
-          <a href="/konnect/" class="{% if include.edition == 'konnect' %}active{% endif %}">Konnect Cloud</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect' %} class="active"{% endif %}>
+          <a href="/konnect/" {% if include.edition == 'konnect' %}class="active"{% endif %}>Konnect Cloud</a>
         </li>
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'mesh' %} class="active" {% endif %}>
-          <a href="/mesh/" class="{% if include.edition == 'mesh' %}active{% endif %}">Kong Mesh</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'mesh' %} class="active"{% endif %}>
+          <a href="/mesh/" {% if include.edition == 'mesh' %}class="active"{% endif %}>Kong Mesh</a>
         </li>
         <li role="menuitem" tabindex="-1">
           <a href="https://kuma.io/docs/" target="_blank">Kuma</a>
@@ -38,29 +38,29 @@
         <li>
           <a href="https://support.insomnia.rest/" target="_blank">Insomnia</a>
         </li>
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'deck' %} class="active" {% endif %}>
-          <a href="/deck/" class="{% if include.edition == 'deck' %}active{% endif %}">decK</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'deck' %} class="active"{% endif %}>
+          <a href="/deck/" {% if include.edition == 'deck' %}class="active"{% endif %}>decK</a>
         </li>
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'kubernetes-ingress-controller' %} class="active" {% endif %}>
-          <a href="/kubernetes-ingress-controller/" class="{% if include.edition == 'kubernetes-ingress-controller' %}active{% endif %}">Kubernetes Ingress Controller</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'kubernetes-ingress-controller' %} class="active"{% endif %}" >
+          <a href="/kubernetes-ingress-controller/" {% if include.edition == 'kubernetes-ingress-controller' %}class="active"{% endif %}>Kubernetes Ingress Controller</a>
         </li>
         <li role="menuitem" tabindex="-1">
           <a href="/hub/">Plugin Hub</a>
         </li>
         <hr>
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect_platform' %} class="active" {% endif %}>
-          <a href="/konnect-platform/" class="{% if include.edition == 'konnect_platform' %}active{% endif %}">Common documentation</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect_platform' %} class="active"{% endif %}>
+          <a href="/konnect-platform/" {% if include.edition == 'konnect_platform' %}class="active"{% endif %}>Common documentation</a>
         </li>
         <hr>
-        <li role="menuitem" tabindex="-1" {% if include.edition == 'contributing' %} class="active" {% endif %}>
-          <a href="/contributing/" class="{% if include.edition == 'contributing' %}active{% endif %}">Docs contribution guidelines</a>
+        <li role="menuitem" tabindex="-1" {% if include.edition == 'contributing' %} class="active"{% endif %}>
+          <a href="/contributing/" {% if include.edition == 'contributing' %}class="active"{% endif %}>Docs contribution guidelines</a>
         </li>
       </ul>
     </div>
 
     {% unless include.no_version == true %}
     <div class="versions-dropdown dropdown">
-      <button class="dropdown-button" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button class="dropdown-button" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
         <span>
           Version {{page.kong_version}}
           {% if page.kong_version == page.kong_latest.release %}
@@ -69,11 +69,11 @@
         </span>
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu dropdown-menu-right" id="version-list" role="menu" aria-labelledby="version-dropdown" tabindex="0">
+      <ul class="dropdown-menu dropdown-menu-right" id="version-list" role="menu" aria-labelledby="version-dropdown" aria-hidden="true">
           {% for ver in include.kong_versions reversed %}
           {% assign version_page_url = include.url | replace: include.kong_version, ver.release %}
           {% capture version_page_exists %}{% page_exists {{version_page_url}} %}{% endcapture %}
-        <li {% if include.kong_version==ver.release %} class="active" {% endif %}>
+        <li {% if include.kong_version==ver.release %}class="active" {% endif %} role="menuitem" tabindex="-1">
           <a href="{% if version_page_exists == 'true' %}{{version_page_url}}{% else %}/{% if include.edition == 'gateway-oss' %}gateway-oss/{% endif %}{% if include.edition == 'enterprise' %}enterprise/{% endif %}{% if page.edition == 'gateway' %}gateway/{% endif %}{% if include.edition == 'mesh' %}mesh/{% endif %}{% if include.edition == 'kubernetes-ingress-controller' %}kubernetes-ingress-controller/{% endif %}{% if include.edition == 'contributing' %}contributing/{% endif %}{% if include.edition == 'deck' %}deck/{% endif %}{{ver.release}}{% endif %}"
             {% if ver.release==include.kong_version %} class="active" {% endif %}
             data-version-id="{{ver.release}}"

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -35,27 +35,17 @@
           <span class="caret"></span>
           <ul class="navbar-item-submenu" role="menu" aria-hidden="true">
             <div class="submenu-section">
-              <span class="navbar-item submenu-section-title">Kong Konnect Platform</span>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/konnect-platform/" class="navbar-item navbar-item-docs">Konnect Platform</a>
+                <a href="/gateway/" class="navbar-item navbar-item-docs">Kong Gateway</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
                 <a href="/konnect/" class="navbar-item navbar-item-docs">Konnect Cloud</a>
-              </li>
-              <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/enterprise/" class="navbar-item navbar-item-docs">Kong Gateway (Enterprise)</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
                 <a href="/mesh/" class="navbar-item navbar-item-docs">Kong Mesh</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
                 <a href="/hub/" class="navbar-item navbar-item-docs">Plugin Hub</a>
-              </li>
-            </div>
-            <div class="submenu-section">
-              <span class="navbar-item submenu-section-title">Open Source</span>
-              <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/gateway-oss/" class="navbar-item navbar-item-docs">Kong Gateway (OSS)</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
                 <a href="/deck/" class="navbar-item navbar-item-docs">decK</a>
@@ -71,19 +61,15 @@
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
                 <a href="https://kuma.io/docs/" target="_blank" class="navbar-item navbar-item-docs">Kuma</a>
               </li>
-            </div>
-            <div class="submenu-section">
-              <span class="navbar-item submenu-section-title">Contribute to the docs</span>
+              <hr>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/contributing/" class="navbar-item navbar-item-docs">Contribution guidelines</a>
+                <a href="/konnect-platform/" class="navbar-item navbar-item-docs">Common documentation</a>
               </li>
-            </div>
-            <div class="submenu-section">
-              <span class="navbar-item submenu-section-title">One Gateway doc (temp location)</span>
+              <hr>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/gateway/" class="navbar-item navbar-item-docs">Kong Gateway</a>
+                <a href="/contributing/" class="navbar-item navbar-item-docs">Doc contribution guidelines</a>
               </li>
-            </div>
+              </div>
           </ul>
         </li>
         <li role="menuitem" tabindex="0" id="support-link" class="main-menu-item">


### PR DESCRIPTION
### Summary
* Simplifying the sidebar and top nav menus to combine gateway OSS and enterprise.
* Making side menu accessible 
  * Can now tab through product and version menus, as well as use the `Escape` key to close a menu to leave it
  * When tabbing over from the dropdowns to the topic nav, dropdowns close
  * Added `tabindex` and `role` to accordion nav (below the dropdowns); this alone doesn't make the content accessible, but it sets us up for creating an accessible menu in the future. 
  
    Note that I added this to the `a` element and not the `li`s - if you add it to `li`s, it creates a double-tab - one that highlights the `li`, and the next one highlights the `a` element inside it. 
  * Added `focus:visible` to show focus outlines when tabbing through dropdowns


### Reason
DOCU-1964; single-sourcing project.

### Testing
Pull down branch and build locally.
