### PR TITLE
[DOCU-1680] Move key concepts

### DIFF
--- a/app/_data/docs_nav_konnect_platform.yml
+++ b/app/_data/docs_nav_konnect_platform.yml
@@ -1,6 +1,9 @@
 - title: Konnect Platform Overview
   icon: /assets/images/icons/documentation/icn-flag.svg
   url: /konnect-platform
+  items:
+    - text: Key Concepts
+      url: /konnect-platform/key-concepts
 
 - title: Konnect Plans
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/konnect-platform/key-concepts.md
+++ b/app/konnect-platform/key-concepts.md
@@ -1,0 +1,25 @@
+---
+title: Key Concepts and Terminology
+no_version: true
+---
+
+Kong uses common terms for entities and processes that have a specific meaning in context. This topic provides a conceptual overview of terms, and how they apply to Kong’s use cases.
+
+## Stages of software availability
+
+### Tech preview
+A feature that is in tech preview might have limited to no documentation, is not guaranteed to be made available as GA in the future, and should not be deployed to production environments.
+
+### Beta
+A Beta designation in Kong software means the functionality of a feature or release version is of high quality and can be deployed in a non-production environment. Note the following when using a Beta feature or version:
+
+* **A Beta feature or version should not be deployed in a production environment.**
+* Beta customers are encouraged to engage Kong Support to report issues encountered in Beta testing. Support requests should be filed with normal priority, but contractual SLA’s will not be applicable for Beta features.
+* Support is not available for data recovery, rollback, or other tasks when using a Beta feature or version.
+* User documentation might not be available, complete, or reflect entire functionality.
+
+A Beta feature or version is made available to the general public for usability testing and to gain feedback about the feature or version before releasing it as a production-ready, stable feature or version.
+
+### General availability
+General availability, or GA, means that the software is released publically and
+is supported according to Kong's [support and maintenance policy](https://konghq.com/wp-content/uploads/2021/04/Kong-Support-and-Maintenance-Policy-16-April-2021.pdf).


### PR DESCRIPTION
### Summary
* Moving the Key Concepts topic from Gateway to a higher up location at `/konnect-platform/`.
* Removing definitions for Kong Gateway elements - the information is all either duplicate or extraneous
* Keeping the definition for beta, as it applies across the board
* Adding short definitions for tech preview and GA, as defined in https://docs.google.com/presentation/d/1GBPlSm-c0lZtPrdaKsgXVouJ875GLEyb_UX4yvM38r4/edit#slide=id.geaebf75f0e_1_0 and tracked in https://konghq.atlassian.net/browse/DOCU-1800; definitions are from Reza and Tom Kaweski

### Reason
https://konghq.atlassian.net/browse/DOCU-1680

### Testing
Tested locally, here's what the new topic looks like:
![Screen Shot 2021-11-04 at 11 02 15 AM](https://user-images.githubusercontent.com/54370747/140396353-7fcae63b-7453-4784-a069-7fa9b55c17e7.png)

