### PR TITLE
[DOCU-1963] Handling access to older split versions and adding announcement

### DIFF
--- a/app/_assets/javascripts/promo-banner.js
+++ b/app/_assets/javascripts/promo-banner.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function () {
-  var closed = localStorage.getItem("closebanner-hackathon");
+  var closed = localStorage.getItem("closebanner-singlesourcing");
   if (
     closed !== "closebanner"
   ) {
@@ -26,5 +26,5 @@ setInterval(function () {
 }, 10);
 $(".closebanner").on("click", function () {
   $(".navbar-v2").addClass("closed");
-  localStorage.setItem("closebanner-hackathon", "closebanner");
+  localStorage.setItem("closebanner-singlesourcing", "closebanner");
 });

--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -36,7 +36,7 @@ body {
         z-index: 9;
         top: 0px;
         overflow: hidden;
-        background: #5d9fff;
+        background: @blue-500;
         align-items: center;
         justify-content: center;
         strong,
@@ -48,7 +48,7 @@ body {
           font-size: 10px;
           text-transform: uppercase;
           background: #fff;
-          color: #5d9fff;
+          color: @blue-500;
           padding: 0rem 1.25rem;
           border-radius: 50px;
           margin-right: 1rem;
@@ -115,27 +115,27 @@ body {
       }
       // uncomment this section when adding a new promo banner
       // also uncomment the promo banner sections in /app/_includes/nav-v2.html and gulpfile.js
-      // header.navbar-v2 {
-      //   transition: transform 0.2s ease-in-out;
-      //   will-change: transform;
-      //   height: 95px;
-      // }
-      //
-      // header.navbar-v2.closed {
-      //   transition: 0s ease-in-out;
-      // }
-      //
-      // header.closed,
-      // header.compress {
-      //   transform: translateY(-35px);
-      // }
-      //
-      // header:not(.closed) ~ .landing-page {
-      //   margin-top: 35px;
-      // }
-      // header:not(.closed) ~ div.page {
-      //   margin-top: 100px;
-      // }
+      header.navbar-v2 {
+        transition: transform 0.2s ease-in-out;
+        will-change: transform;
+        height: 95px;
+      }
+
+      header.navbar-v2.closed {
+        transition: 0s ease-in-out;
+      }
+
+      header.closed,
+      header.compress {
+        transform: translateY(-35px);
+      }
+
+      header:not(.closed) ~ .landing-page {
+        margin-top: 35px;
+      }
+      header:not(.closed) ~ div.page {
+        margin-top: 100px;
+      }
     }
   }
 }

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -1,4 +1,5 @@
 -
+# Old OSS Gateway docs
   release: "0.2.x"
   version: "0.2.1"
   edition: "gateway-oss"
@@ -294,20 +295,7 @@
     libyaml: "0.2.5"
     pcre: "8.44"
 -
-  release: "2.6.x"
-  version: "2.6.0"
-  edition: "gateway-oss"
-  luarocks_version: "2.5.1-0"
-  dependencies:
-    luajit: "2.1.0-beta3"
-    luarocks: "3.7.0"
-    cassandra: "3.x.x"
-    postgres: "9.5+"
-    openresty: "1.19.3.2"
-    openssl: "1.1.1k"
-    libyaml: "0.2.5"
-    pcre: "8.44"
--
+# Old Enterprise Gateway docs
   release: "0.31-x"
   version: "0.31"
   edition: "enterprise"
@@ -464,24 +452,23 @@
     postgres: "9.5+"
     openresty: "1.19.3.1"
   lua_doc: true
-
 -
+# Combined Gateway docs (single-sourced)
   release: "2.6.x"
-  version: "2.6.0.0"
-  edition: "enterprise"
-  luarocks_version: "2.2.0.0"
+  ee-version: "2.6.0.0"
+  ce-version: "2.6.0"
+  edition: "gateway"
+  luarocks_version: "2.5.1-0"
   dependencies:
     luajit: "2.1.0-beta3"
     luarocks: "3.7.1"
     cassandra: "3.x.x"
     postgres: "9.5+"
-    openresty: "1.19.3.1"
+    openresty: "1.19.3.2"
+    openssl: "1.1.1k"
+    libyaml: "0.2.5"
+    pcre: "8.44"
   lua_doc: true
--
-  release: "2.6.x"
-  ee-version: "2.6.0.0"
-  ce-version: "2.6.0"
-  edition: "gateway"
 -
   release: "CE-2.0.x_KE-1.5.x"
   version: "CE-2.0.x/KE-1.5.x"
@@ -505,10 +492,6 @@
 -
   release: "2.5.x"
   version: "2.5"
-  edition: "getting-started-guide"
--
-  release: "2.6.x"
-  version: "2.6"
   edition: "getting-started-guide"
 -
   release: "pre-1.7"

--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -63,13 +63,20 @@
       <button class="dropdown-button" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
         <span>
           Version {{page.kong_version}}
-          {% if page.kong_version == page.kong_latest.release %}
+          {% if page.kong_version == page.kong_latest.release and page.edition != 'gateway-oss' and page.edition != 'enterprise' and page.edition != 'getting-started-guide' %}
             <span>(latest)</span>
           {% endif %}
         </span>
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" id="version-list" role="menu" aria-labelledby="version-dropdown" aria-hidden="true">
+        {% if include.edition == 'gateway-oss' or include.edition == 'enterprise' or include.edition == 'getting-started-guide' %}
+        <li role="menuitem" tabindex="-1">
+          <a href="/gateway/">
+            Later versions (Enterprise and OSS)
+          </a>
+        </li>
+        {% endif %}
           {% for ver in include.kong_versions reversed %}
           {% assign version_page_url = include.url | replace: include.kong_version, ver.release %}
           {% capture version_page_exists %}{% page_exists {{version_page_url}} %}{% endcapture %}
@@ -79,11 +86,23 @@
             data-version-id="{{ver.release}}"
           >
             {{ver.release}}
-            {% if ver.release == page.kong_latest.release %} <em>(latest)</em>
+            {% if ver.release == page.kong_latest.release and include.edition != 'enterprise' and include.edition != 'gateway-oss' and page.edition != 'getting-started-guide' %} <em>(latest)</em>
             {% endif %}
           </a>
         </li>
         {% endfor %}
+        {% if include.edition == 'gateway' %}
+        <li role="menuitem" tabindex="-1">
+          <a href="/enterprise/">
+            Older Enterprise versions
+          </a>
+        </li>
+        <li role="menuitem" tabindex="-1">
+          <a href="/gateway-oss/">
+            Older OSS versions
+          </a>
+        </li>
+        {% endif %}
       </ul>
     </div>
     {% endunless %}

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -2,12 +2,12 @@
   <a class="skip-main" href="#main">Skip to content</a>
   <!-- uncomment the promo-banner div when adding a new promo banner
   <!--also uncomment the promo banner sections in app/assets/stylesheets/header.less and gulpfile.js-->
-  <!-- <div id="promo-banner">
+  <div id="promo-banner">
     <div class="container">
-      <div class="closebanner"></div> <strong><label>EVENT</label> Join the Kong Summit Hackathon &nbsp;&mdash;<a target="_blank"
-          href="https://konghq.com/summit-hackathon">Start Hacking &rarr;</a></strong>
+      <div class="closebanner"></div> <strong><label>NEW</label> The Kong Gateway OSS and Enterprise docs are now combined! &nbsp;&mdash;<a
+          href="/gateway/">See the docs &rarr;</a></strong>
     </div>
-  </div> -->
+  </div>
   <div class="navbar-content">
     <a href="https://konghq.com" class="navbar-brand col col-xl-auto">
       <img src="/assets/images/logos/kong-logo-blue.svg" alt="Kong Logo" id="kong-logo">

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -60,7 +60,7 @@ page.kong_latest.release %}
             {% unless page.no_version == true %}
               <div class="content-version">
                 {{page.kong_version}}
-                  {% if page.kong_version == page.kong_latest.release %}
+                  {% if page.kong_version == page.kong_latest.release and page.edition != 'gateway-oss' and page.edition != 'enterprise' and page.edition != 'getting-started-guide' %}
                   <span>(latest)</span>
                 {% endif %}
               </div>
@@ -69,18 +69,15 @@ page.kong_latest.release %}
               {% include_cached breadcrumbs.html edition=page.edition no_version=page.no_version has_version=page.has_version kong_version=page.kong_version url=page.url dir=page.dir%}
             {% endunless %}
           </div>
-          {% if page.edition == 'gateway-oss' %}
-            <div class="alert alert-ee">
-            Maybe you were looking for the <a href="/enterprise">
-                <strong>{{site.ee_product_name}} documentation</strong>
-              </a>
-            instead?
-          </div>
+          {% if page.edition == 'gateway-oss' or page.edition == 'enterprise' %}
+          <blockquote class="note">
+            The <a href="/gateway/">latest {{site.base_gateway}} documentation </a> is now available as a combined doc set for both open-source and Enterprise Gateway.
+          </blockquote>
           {% endif %}
             {% if page.kong_version != page.kong_latest.release and page.no_version != true %}
               <div class="alert alert-warning">
               You are browsing documentation for an outdated version. See the
-              <a href="{% if latest_page_exists == 'true' %}{{latest_page_url}}{% elsif page.edition == 'gateway-oss'%}/gateway-oss/{% elsif page.edition == 'enterprise'%}/enterprise/{% elsif page.edition == 'mesh'%}/mesh/{% elsif page.edition == 'kubernetes-ingress-controller/'%}/kubernetes-ingress-controller/{% else %}/{% endif %}">
+              <a href="{% if latest_page_exists == 'true' %}{{latest_page_url}}{% elsif page.edition == 'gateway-oss' or page.edition == 'enterprise' or page.edition == 'gateway' %}/gateway/{% elsif page.edition == 'mesh'%}/mesh/{% elsif page.edition == 'kubernetes-ingress-controller/'%}/kubernetes-ingress-controller/{% else %}/{% endif %}">
                 latest documentation here</a>.
               </div>
             {% endif %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ var sources = {
     paths.assets + "javascripts/feedback-widget.js",
     // uncomment the path to promo-banner.js when adding a new promo banner
     // also uncomment the promo banner sections in app/_assets/stylesheets/header.less and /app/_includes/nav-v2.html -->
-    // paths.assets + "javascripts/promo-banner.js",
+    paths.assets + "javascripts/promo-banner.js",
     paths.assets + "javascripts/copy-code-snippet-support.js"
   ],
   images: paths.assets + "images/**/*",


### PR DESCRIPTION
### Summary
* Setting up cross-document access between older (split) and newer (combined) versions of the Gateway doc.
  * Combined Gateway doc (`/gateway/`) has version entries for "Older Enterprise versions" and "Older OSS versions"
  
  ![Screen Shot 2021-11-04 at 6 08 09 PM](https://user-images.githubusercontent.com/54370747/140441920-6a8e250f-812f-47db-a659-e49867753b6e.png)

  * Old Gateway OSS (`gateway-oss`) and Gateway Enterprise (`/enterprise/`) docs link back to `/gateway/` for the latest version
  
  ![Screen Shot 2021-11-04 at 6 16 31 PM](https://user-images.githubusercontent.com/54370747/140442197-ff35d723-9b21-404d-be3c-cd5955b0e842.png)

  * Added blue banner to the Gateway OSS and Enterprise docs specifically: currently, this probably seems like overkill, but we should leave this banner up indefinitely, while the promo banner (very top of the page) will eventually be removed
  
  ![Screen Shot 2021-11-04 at 6 15 07 PM](https://user-images.githubusercontent.com/54370747/140442222-5f8adfe0-7417-489b-856b-141795b41aa7.png)

* Enabling promo banner with doc announcement
  * adjusting banner colour for more contrast
  
  ![Screen Shot 2021-11-04 at 6 17 52 PM](https://user-images.githubusercontent.com/54370747/140442244-e5420489-fdda-4ad4-84d2-a31ce2315210.png)


### Reason
Since we're removing the split Gateway versions from the dropdown, we need to retain access to the split versions in some way. 

### Testing
Pull down branch and test locally.