### PR TITLE
Kubernetes plus install

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -11,7 +11,7 @@
       url: /install-and-run/kubernetes
     - text: Helm
       url: /install-and-run/helm
-    - text: OpenShift
+    - text: OpenShift with Helm
       url: /install-and-run/openshift
     - text: Docker
       url: /install-and-run/docker

--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -7,6 +7,12 @@
   icon: /assets/images/icons/documentation/icn-deployment-color.svg
   url: /install-and-run/
   items:
+    - text: Kubernetes
+      url: /install-and-run/kubernetes
+    - text: Helm
+      url: /install-and-run/helm
+    - text: OpenShift
+      url: /install-and-run/openshift
     - text: Docker
       url: /install-and-run/docker
     - text: Amazon Linux

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -1,9 +1,8 @@
 ---
 title: Install on Kubernetes with Helm
-badge: enterprise
 ---
 
-This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a [flat Kubernetes manifest](/gateway/{{page.kong_version}}/install-and-run/kubernetes).
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} using Helm. The Enterprise deployment includes a Postgres sub-chart provided by Bitnami. The documentation on installing with a [flat Kubernetes manifest](/gateway/{{page.kong_version}}/install-and-run/kubernetes) also explains how to install in DB-less mode for both Enterprise and OSS deployments.
 
 ## Prerequisites
 
@@ -20,16 +19,6 @@ Create the namespace for {{site.base_gateway}} with {{site.kic_product_name}}. F
 kubectl create namespace kong
 ```
 
-## Create license secret
-
-1.  Save your license file temporarily with the filename `license` (no file extension).
-
-1.  Run:
-
-    ```sh
-    kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
-    ```
-
 ## Set up Helm
 
 1.  Add the Kong charts repository:
@@ -44,9 +33,21 @@ kubectl create namespace kong
     helm repo update
     ```
 
-## Create secret for RBAC superuser (recommended)
+## Create license secret
+{:.badge .enterprise}
 
-If you plan to use RBAC, you must create the superuser account at this step in installation. You cannot create it later.
+1.  Save your license file temporarily with the filename `license` (no file extension).
+
+1.  Run:
+
+    ```sh
+    kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+    ```
+
+## Create secret for RBAC superuser (recommended)
+{:.badge .enterprise}
+
+If you plan to use RBAC, you must create a secret for the superuser account password at this step in installation. You cannot create it later.
 
 1.  Create the RBAC account.
 
@@ -59,6 +60,7 @@ If you plan to use RBAC, you must create the superuser account at this step in i
     ```
 
 ## Create secret for Session plugin
+{:.badge .enterprise}
 
 If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal, you must also configure the Session plugin and store its config in a Kubernetes secret:
 
@@ -79,19 +81,27 @@ kubectl create secret generic kong-session-config \
 --from-file=portal_session_conf
 ```
 
-## Create `values.yaml` file
+## Create values.yaml file
 
-Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. Work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. The [readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md) includes an exhaustive list of all possible configuration properties.
+Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. You can work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. For OSS deployments, the default install might be sufficient, but you can explore other `values.yaml` files and [the readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md), which includes an exhaustive list of all possible configuration properties.
 
-Note that this deployment includes a Postgres sub-chart provided by Bitnami. You might need to delete the PersistentVolume objects for Postgres in your Kubernetes cluster to connect to the database after install.
+Note that the Enterprise deployment includes a Postgres sub-chart provided by Bitnami. You might need to delete the PersistentVolume objects for Postgres in your Kubernetes cluster to connect to the database after install.
 
 ## Deploy {{site.base_gateway}} with {{site.kic_product_name}}
 
 1.  Run:
 
     ```sh
+    ## Kong Gateway
     helm install my-kong kong/kong -n kong --values ./values.yaml
     ```
+
+    ```sh
+    ## Kong Gateway (OSS)
+    helm install kong/kong --generate-name --set ingressController.installCRDs=false
+    ```
+
+    For more information on working with Helm charts for {{site.ce_product_name}}, see the [chart documentation](https://github.com/Kong/charts/blob/main/charts/kong/README.md).
 
     This might take some time.
 
@@ -102,6 +112,7 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
     ```
 
 ## Finalize configuration and verify installation
+{:.badge .enterprise}
 
 1.  Run:
 
@@ -145,4 +156,7 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
     my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
     my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
     ```
-    
+
+## Next steps
+
+See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -3,7 +3,7 @@ title: Install on Kubernetes with Helm
 badge: enterprise
 ---
 
-This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a flat Kubernetes manifest.
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a [flat Kubernetes manifest](/gateway/{{page.kong_version}}/install-and-run/kubernetes).
 
 ## Prerequisites
 
@@ -55,7 +55,7 @@ If you plan to use RBAC, you must create the superuser account at this step in i
     ```sh
     kubectl create secret generic kong-enterprise-superuser-password \
     n kong \
-    --from-literal=password=<your-password>
+    --from-literal=password={YOUR_PASSWORD}
     ```
 
 ## Create secret for Session plugin
@@ -95,7 +95,7 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
 
     This might take some time.
 
-1.  Check pod status, and make sure the `my-kong-kong-<ID>` pod is running:
+1.  Check pod status, and make sure the `my-kong-kong-{ID}` pod is running:
 
     ```bash
     kubectl get pods -n kong
@@ -114,7 +114,7 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
 1.  Copy the IP address from the output, then add the following to the `.env` section of your `values.yaml` file:
 
     ```yaml
-    admin_api_uri: <your-DNS-or-IP>
+    admin_api_uri: {YOUR-DNS-OR-IP}
     ```
 
     {:.Note}

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -81,7 +81,7 @@ kubectl create secret generic kong-session-config \
 
 ## Create `values.yaml` file
 
-Create your `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. Work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. The [readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md) includes an exhaustive list of all possible configuration properties.
+Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. Work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. The [readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md) includes an exhaustive list of all possible configuration properties.
 
 Note that this deployment includes a Postgres sub-chart provided by Bitnami. You might need to delete the PersistentVolume objects for Postgres in your Kubernetes cluster to connect to the database after install.
 
@@ -132,6 +132,12 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
     helm upgrade my-kong kong/kong -n kong --values ./values.yaml
     ```
 
+1.  After the upgrade finishes, run:
+
+    ```
+    kubectl get svc -n kong
+    ```
+
     The output includes `EXTERNAL-IP` values for Kong Manager and Dev Portal. For example:
 
     ```sh
@@ -139,3 +145,4 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
     my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
     my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
     ```
+    

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -1,0 +1,141 @@
+---
+title: Install on Kubernetes with Helm
+badge: enterprise
+---
+
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a flat Kubernetes manifest.
+
+## Prerequisites
+
+- A Kubernetes cluster, v1.19 or later
+- `kubectl` v1.19 or later
+- (Enterprise only) A `license.json` file from Kong
+- Helm 3
+
+## Create namespace
+
+Create the namespace for {{site.base_gateway}} with {{site.kic_product_name}}. For example:
+
+```sh
+kubectl create namespace kong
+```
+
+## Create license secret
+
+1.  Save your license file temporarily with the filename `license` (no file extension).
+
+1.  Run:
+
+    ```sh
+    kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+    ```
+
+## Set up Helm
+
+1.  Add the Kong charts repository:
+
+    ```sh
+    helm repo add kong https://charts.konghq.com
+    ```
+
+1.  Update Helm:
+
+    ```sh
+    helm repo update
+    ```
+
+## Create secret for RBAC superuser (recommended)
+
+If you plan to use RBAC, you must create the superuser account at this step in installation. You cannot create it later.
+
+1.  Create the RBAC account.
+
+1.  Create the secret:
+
+    ```sh
+    kubectl create secret generic kong-enterprise-superuser-password \
+    n kong \
+    --from-literal=password=<your-password>
+    ```
+
+## Create secret for Session plugin
+
+If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal, you must also configure the Session plugin and store its config in a Kubernetes secret:
+
+For Kong Manager only:
+
+```sh
+kubectl create secret generic kong-session-config \
+-n kong \
+--from-file=admin_gui_session_conf
+```
+
+For Kong Manager and Dev Portal:
+
+```sh
+kubectl create secret generic kong-session-config \
+-n kong \
+--from-file=admin_gui_session_conf \
+--from-file=portal_session_conf
+```
+
+## Create `values.yaml` file
+
+Create your `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. Work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. The [readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md) includes an exhaustive list of all possible configuration properties.
+
+Note that this deployment includes a Postgres sub-chart provided by Bitnami. You might need to delete the PersistentVolume objects for Postgres in your Kubernetes cluster to connect to the database after install.
+
+## Deploy {{site.base_gateway}} with {{site.kic_product_name}}
+
+1.  Run:
+
+    ```sh
+    helm install my-kong kong/kong -n kong --values ./values.yaml
+    ```
+
+    This might take some time.
+
+1.  Check pod status, and make sure the `my-kong-kong-<ID>` pod is running:
+
+    ```bash
+    kubectl get pods -n kong
+    ```
+
+## Finalize configuration and verify installation
+
+1.  Run:
+
+    ```sh
+    kubectl get svc my-kong-kong-admin \
+    -n kong \
+    --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ```
+
+1.  Copy the IP address from the output, then add the following to the `.env` section of your `values.yaml` file:
+
+    ```yaml
+    admin_api_uri: <your-DNS-or-IP>
+    ```
+
+    {:.Note}
+    > **Note:** If you configure RBAC, you must specify a DNS hostname instead of an IP address.
+
+1.  Clean up:
+
+    ```sh
+    kubectl delete jobs -n kong --all
+    ```
+
+1.  Update with changed `values.yaml`:
+
+    ```
+    helm upgrade my-kong kong/kong -n kong --values ./values.yaml
+    ```
+
+    The output includes `EXTERNAL-IP` values for Kong Manager and Dev Portal. For example:
+
+    ```sh
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                            AGE
+    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
+    my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
+    ```

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -2,9 +2,11 @@
 title: Install on Kubernetes
 ---
 
-This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with Helm. This page includes the equivalent commands for OpenShift.
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with [Helm](/gateway/{{page.kong_version}}/install-and-run/helm). 
 
-Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native datastore. For more information see [TODO LINK]().
+This page also includes the equivalent commands for OpenShift.
+
+Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native datastore. For more information see [Kubernetes Deployment Options](/gateway/{{page.kong_version}}/plan-and-deploy/kubernetes-deployment-options).
 
 ## Prerequisites
 

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -66,7 +66,7 @@ oc new-project kong
 
     This might take a few minutes.
 
-2.  Check the install status:
+1.  Check the install status:
 
     ```sh
     kubectl get pods -n kong
@@ -78,13 +78,13 @@ oc new-project kong
     oc get pods -n kong
     ```
 
-3.  To make HTTP requests, you need the IP address of the load balancer. Get the LoadBalancer address and store it in a local PROXY_IP environment variable: 
+1.  To make HTTP requests, you need the IP address of the load balancer. Get the LoadBalancer address and store it in a local PROXY_IP environment variable: 
 
     ```sh
     export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
     ```
 
-4.  Check that the value of $PROXY_IP is the value of the external host:
+1.  Check that the value of $PROXY_IP is the value of the external host:
 
     ```sh
     kubectl get service kong-proxy -n kong
@@ -98,7 +98,13 @@ oc new-project kong
 
     {:.Note}
     > **Note:** Some cluster providers provide only a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
-    
+
+## Next steps
+
+See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
+
+
+
 
 
 

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -1,0 +1,41 @@
+---
+title: Install on Kubernetes
+---
+
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with Helm.
+
+Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native datastore. For more information see [TODO LINK]().
+
+## Prerequisites
+
+- A Kubernetes cluster, v1.19 or later
+- `kubectl` v1.19 or later
+- (Enterprise only) A `license.json` file from Kong
+
+## Create namespace
+
+Create the namespace for {{site.base_gateway}} with {{site.kic_product_name}}. For example:
+
+```sh
+kubectl create namespace kong
+```
+
+## Create license secret
+{:.badge .enterprise}
+
+1.  Save your license file temporarily with the filename `license` (no file extension).
+
+1.  Run:
+
+    ```sh
+    kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+    ```
+
+
+
+
+
+
+
+
+

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -2,7 +2,7 @@
 title: Install on Kubernetes
 ---
 
-This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with Helm.
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with Helm. This page includes the equivalent commands for OpenShift.
 
 Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native datastore. For more information see [TODO LINK]().
 
@@ -17,7 +17,13 @@ Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernete
 Create the namespace for {{site.base_gateway}} with {{site.kic_product_name}}. For example:
 
 ```sh
+## on Kubernetes native
 kubectl create namespace kong
+```
+
+```sh
+## on OpenShift
+oc new-project kong
 ```
 
 ## Create license secret
@@ -28,9 +34,69 @@ kubectl create namespace kong
 1.  Run:
 
     ```sh
+    ## on Kubernetes native
     kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
     ```
 
+    ```sh
+    ## on OpenShift
+    oc create secret generic kong-enterprise-license --from-file=./license -n kong
+    ```
+
+## Deploy
+
+1.  Run one of the following:
+
+    ```sh
+    ## Kong Gateway on Kubernetes native
+    kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+    ```
+
+    ```sh
+    ## Kong Gateway on OpenShift
+    oc create -f https://bit.ly/k4k8s-enterprise-install
+    ```
+
+    ```sh
+    ## Kong Gateway (OSS) on Kubernetes native
+    kubectl apply -f https://bit.ly/kong-ingress-dbless
+    ```
+
+    This might take a few minutes.
+
+2.  Check the install status:
+
+    ```sh
+    kubectl get pods -n kong
+    ```
+
+    or:
+
+    ```sh
+    oc get pods -n kong
+    ```
+
+3.  To make HTTP requests, you need the IP address of the load balancer. Get the LoadBalancer address and store it in a local PROXY_IP environment variable: 
+
+    ```sh
+    export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
+    ```
+
+4.  Check that the value of $PROXY_IP is the value of the external host:
+
+    ```sh
+    kubectl get service kong-proxy -n kong
+    ```
+
+    or:
+
+    ```sh
+    oc get service kong-proxy -n kong
+    ```
+
+    {:.Note}
+    > **Note:** Some cluster providers provide only a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
+    
 
 
 

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -55,29 +55,50 @@ If you plan to use RBAC, you must create the superuser account at this step in i
     ```sh
     oc create secret generic kong-enterprise-superuser-password \
     -n kong \
-    --from-literal=password=<your-password>
+    --from-literal=password={your-password}
     ```
 
 ## Create secret for Session plugin
 
 If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal, you must also configure the Session plugin and store its config in a Kubernetes secret:
 
-For Kong Manager only:
+1.  Create a session config file for Kong Manager:
 
-```sh
-oc create secret generic kong-session-config \
--n kong \
---from-file=admin_gui_session_conf
-```
+    ```bash
+    $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
+    ```
 
-For Kong Manager and Dev Portal:
+1.  Create a session config file for Kong Dev Portal:
 
-```sh
-oc create secret generic kong-session-config \
--n kong \
---from-file=admin_gui_session_conf \
---from-file=portal_session_conf
-```
+    ```bash
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    ```
+
+    Or, if you have different subdomains for the `portal_api_url` and `portal_gui_host`, set the `cookie_domain`
+    and `cookie_samesite` properties as follows:
+
+    ```
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    ```
+
+1.  Create the secret:
+
+    For Kong Manager only:
+
+    ```sh
+    oc create secret generic kong-session-config \
+    -n kong \
+    --from-file=admin_gui_session_conf
+    ```
+
+    For Kong Manager and Dev Portal:
+
+    ```sh
+    oc create secret generic kong-session-config \
+    -n kong \
+    --from-file=admin_gui_session_conf \
+    --from-file=portal_session_conf
+    ```
 
 ## Create values.yaml file
 

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -3,7 +3,7 @@ title: Install on OpenShift with Helm
 badge: enterprise
 ---
 
-This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a flat Kubernetes manifest.
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a [flat Kubernetes manifest](/gateway/{{page.kong_version}}/install-and-run/kubernetes).
 
 ## Prerequisites
 

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -79,7 +79,7 @@ oc create secret generic kong-session-config \
 --from-file=portal_session_conf
 ```
 
-## Create `values.yaml` file
+## Create values.yaml file
 
 Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. Work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. The [readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md) includes an exhaustive list of all possible configuration properties.
 
@@ -145,4 +145,7 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
     my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
     my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
     ```
-    
+
+## Next steps
+
+See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -1,0 +1,6 @@
+---
+title: Install on OpenShift with Helm
+badge: enterprise
+---
+
+TK

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -3,4 +3,146 @@ title: Install on OpenShift with Helm
 badge: enterprise
 ---
 
-TK
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a flat Kubernetes manifest.
+
+## Prerequisites
+
+- A Kubernetes cluster, v1.19 or later
+- `kubectl` v1.19 or later
+- (Enterprise only) A `license.json` file from Kong
+- Helm 3
+
+## Create namespace
+
+Create the namespace for {{site.base_gateway}} with {{site.kic_product_name}}. For example:
+
+```sh
+oc new-project kong
+```
+
+## Create license secret
+
+1.  Save your license file temporarily with the filename `license` (no file extension).
+
+1.  Run:
+
+    ```sh
+    oc create secret generic kong-enterprise-license -n kong --from-file=./license
+    ```
+
+## Set up Helm
+
+1.  Add the Kong charts repository:
+
+    ```sh
+    helm repo add kong https://charts.konghq.com
+    ```
+
+1.  Update Helm:
+
+    ```sh
+    helm repo update
+    ```
+
+## Create secret for RBAC superuser (recommended)
+
+If you plan to use RBAC, you must create the superuser account at this step in installation. You cannot create it later.
+
+1.  Create the RBAC account.
+
+1.  Create the secret:
+
+    ```sh
+    oc create secret generic kong-enterprise-superuser-password \
+    -n kong \
+    --from-literal=password=<your-password>
+    ```
+
+## Create secret for Session plugin
+
+If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal, you must also configure the Session plugin and store its config in a Kubernetes secret:
+
+For Kong Manager only:
+
+```sh
+oc create secret generic kong-session-config \
+-n kong \
+--from-file=admin_gui_session_conf
+```
+
+For Kong Manager and Dev Portal:
+
+```sh
+oc create secret generic kong-session-config \
+-n kong \
+--from-file=admin_gui_session_conf \
+--from-file=portal_session_conf
+```
+
+## Create `values.yaml` file
+
+Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. Work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. The [readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md) includes an exhaustive list of all possible configuration properties.
+
+Note that this deployment includes a Postgres sub-chart provided by Bitnami. You might need to delete the PersistentVolume objects for Postgres in your Kubernetes cluster to connect to the database after install.
+
+## Deploy {{site.base_gateway}} with {{site.kic_product_name}}
+
+1.  Run:
+
+    ```sh
+    helm install my-kong kong/kong -n kong --values ./values.yaml
+    ```
+
+    This might take some time.
+
+1.  Check pod status, and make sure the `my-kong-kong-<ID>` pod is running:
+
+    ```bash
+    oc get pods -n kong
+    ```
+
+## Finalize configuration and verify installation
+
+1.  Run:
+
+    ```sh
+    oc get svc my-kong-kong-admin \
+    -n kong \
+    --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ```
+
+1.  Copy the IP address from the output, then add the following to the `.env` section of your `values.yaml` file:
+
+    ```yaml
+    admin_api_uri: <your-DNS-or-IP>
+    ```
+
+    {:.Note}
+    > **Note:** If you configure RBAC, you must specify a DNS hostname instead of an IP address.
+
+1.  Clean up:
+
+    ```sh
+    oc delete jobs -n kong --all
+    ```
+
+1.  Update with changed `values.yaml`:
+
+    ```
+    helm upgrade my-kong kong/kong -n kong --values ./values.yaml
+    ```
+
+1.  After the upgrade finishes, run:
+
+    ```
+    oc get svc -n kong
+    ```
+
+    The output includes `EXTERNAL-IP` values for Kong Manager and Dev Portal. For example:
+
+    ```sh
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                            AGE
+    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
+    my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
+    ```
+    


### PR DESCRIPTION
### Summary
Add files for installing Gateway on Kubernetes: db-less w/ manifest, database w/ Helm, OpenShift (somewhat hacky).

EDITED NOV. 10, AFTER COMMIT no. 4

- links added, with thanks to @lena-larionova 
- OSS added to Helm, some related things moved around (might be a bit more to do here)
- Intro to Helm edited to attempt explanation of OSS without DB and Enterprise with
- Next steps added

### Reason
single-sourcing project

### Testing
tested locally
