### PR TITLE
Manual upgrade changes

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -23,8 +23,10 @@
       url: /install-and-run/ubuntu
     - text: Migrating from OSS to EE
       url: /install-and-run/migrate-ce-to-ke
-    - text: Upgrade Guide
-      url: /install-and-run/upgrade
+    - text: Upgrade Kong Gateway
+      url: /install-and-run/upgrade-enterprise
+    - text: Upgrade Kong Gateway OSS
+      url: /install-and-run/upgrade-oss
 
 - title: Get Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg

--- a/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
@@ -1,13 +1,17 @@
 ---
-title: Upgrade Guide
+title: Upgrade Kong Gateway
 toc: true
+badge: enterprise
 ---
 
-Upgrade to major, minor, and patch Kong Gateway releases using the
+## Overview
+
+Upgrade to major, minor, and patch {{site.ee_product_name}} releases using the
 `kong migrations` commands.
 
-You can also use the commands to migrate all Kong Gateway OSS entities to Kong Gateway Enterprise. See
-[Migrating from Kong Gateway OSS to Kong Gateway Enterprise](/upgrades/migrate-ce-to-ke/).
+You can also use the commands to migrate all {{site.ce_product_name}} entities
+to {{site.ee_product_name}}. See
+[Migrating from Kong Gateway to Kong Enterprise](/enterprise/{{page.kong_version}}/deployment/upgrades/migrate-ce-to-ke/).
 
 If you experience any issues when running migrations, contact
 [Kong Support](https://support.konghq.com/support/s/) for assistance.
@@ -22,29 +26,27 @@ from which you are migrating:
 - Upgrading from 2.5.x to 2.6.x is a minor upgrade; however, read below for important
 instructions on [database migration](#migrate-db), especially for Cassandra users.
 
-- Upgrading from from 1.x is a major upgrade. Follow the [Version Prerequisites](#version-prerequisites).
+- Upgrading from from 1.x is a major upgrade. Follow the [Version Prerequisites](#prereqs-v).
 Be aware of any noted breaking changes as documented in the version to which you are upgrading.
 
-### Version prerequisites
+### Version prerequisites for migrating to Kong Gateway 2.6.x {#prereqs-v}
 
-If you're not on Kong Gateway 2.5.x, you must first incrementally
+If you are not on {{site.ee_product_name}} 2.5.x, you must first incrementally
 upgrade to 2.5.x before upgrading to 2.6.x. Zero downtime is possible but _not_
 guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1.3.x to
 1.5.x to 2.1.x to 2.2.x to 2.3.x to 2.4.x to 2.5.x to 2.6.x., plan accordingly.
 
-#### Enterprise instructions
-
-* If running a version of Kong Gateway earlier than 1.5,
+* If running a version of {{site.ee_product_name}} earlier than 1.5,
   [migrate to 1.5](/enterprise/1.5.x/deployment/migrations/) first.
-* If running a version of Kong Gateway earlier than 2.1,
+* If running a version of {{site.ee_product_name}} earlier than 2.1,
   [migrate to 2.1](/enterprise/2.1.x/deployment/upgrades/migrations/) first.
-* If running a version of Kong Gateway earlier than 2.2,
+* If running a version of {{site.ee_product_name}} earlier than 2.2,
   [migrate to 2.2](/enterprise/2.2.x/deployment/upgrades/migrations/) first.
-* If running a version of Kong Gateway earlier than 2.3,
+* If running a version of {{site.ee_product_name}} earlier than 2.3,
   [migrate to 2.3](/enterprise/2.3.x/deployment/upgrades/migrations/) first.
-* If running a version of Kong Gateway earlier than 2.4,
+* If running a version of {{ site.ee_product_name }} earlier than 2.4,
   [migrate to 2.4](/enterprise/2.4.x/deployment/upgrades/migrations/) first.
-* If running a version of Kong Gateway earlier than 2.5,
+* If running a version of {{ site.ee_product_name }} earlier than 2.5,
   [migrate to 2.5](/enterprise/2.5.x/deployment/upgrades/migrations/) first.
 
 ### Dev Portal migrations
@@ -52,10 +54,10 @@ guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1
 There are no migrations necessary for the Dev Portal when upgrading from 2.5.x to
 2.6.x.
 
-If you're currently using the Dev Portal in 1.5.x, it will no longer work without
+If you are currently using the Developer Portal in 1.5.x, it will no longer work without
 [manually migrating files](/enterprise/2.1.x/developer-portal/latest-migrations) to version 2.1.x.
 
-## Upgrade considerations
+### Upgrade considerations
 
 Before upgrading, review this list for any configuration or breaking changes that
 affect your current installation.
@@ -64,61 +66,13 @@ affect your current installation.
   `kong migrations up` with the plugin name specified. For example,
   `KONG_PLUGINS=oauth2`.
 
-### Dependencies
-
-If you're using the provided binary packages, all necessary dependencies
-for the gateway are bundled and you can skip this section.
-
-If you're building your dependencies by hand, there are changes since the
-previous release, so you will need to rebuild them with the latest patches.
-
-The required OpenResty version for Kong 2.6.x is
-[1.19.9.1](https://openresty.org/en/changelog-1019003.html). This is more recent
-than the version in Kong 2.5.0 (which used `1.19.3.2`). In addition to an upgraded
-OpenResty, you will need the correct [OpenResty patches](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools/openresty-patches)
-for this new version, including the latest release of [lua-kong-nginx-module](https://github.com/Kong/lua-kong-nginx-module).
-The [kong-build-tools](https://github.com/Kong/kong-build-tools)
-repository contains [openresty-build-tools](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools),
-which allows you to more easily build OpenResty with the necessary patches and modules.
-
-There is a new way to deploy Go using Plugin Servers.
-For more information, see [Developing Go plugins](https://docs.konghq.com/gateway-oss/2.6.x/external-plugins/#developing-go-plugins).
-
-
-There are **Changes in the Nginx configuration file**, between Kong 2.0.x,
-2.1.x, 2.2.x, 2.3.x, 2.4.x and 2.5.x.
-
-To view the configuration changes between versions, clone the
-[Kong repository](https://github.com/kong/kong) and run `git diff`
-on the configuration templates, using `-w` for greater readability.
-
-Here's how to see the differences between previous versions and 2.6.x:
-
-```bash
-git clone https://github.com/Kong/kong
-cd kong
-git diff -w 2.0.0 2.6.0 kong/templates/nginx_kong*.lua
-```
-
-**Note:** Adjust the starting version number
-(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you're currently using.
-
-To produce a patch file, use the following command:
-
-```bash
-git diff 2.0.0 2.6.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
-```
-
-**Note:** Adjust the starting version number
-(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you're currently using.
-
 ### Hybrid mode considerations
 
 {:.important}
-> **Important:** If you're currently running in [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
+> **Important:** If you are currently running in [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
 upgrade the Control Plane first, and then the Data Planes.
 
-* If you're currently running 2.6.x in classic (traditional)
+* If you are currently running 2.6.x in classic (traditional)
   mode and want to run in hybrid mode instead, follow the hybrid mode
   [installation instructions](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)
   after running the migration.
@@ -137,7 +91,7 @@ traffic and old pods are terminated. Once this is complete, the chart spawns ano
 to run `kong migrations finish`.
 
 While the migrations themselves are automated, the chart does not automatically ensure 
-that you follow the recommended upgrade path. If you're upgrading from more than one minor 
+that you follow the recommended upgrade path. If you are upgrading from more than one minor 
 Kong version back, check the upgrade path recommendations for Kong open source or Kong Gateway.
 
 Although not required, users should upgrade their chart version and Kong version independently. 
@@ -182,24 +136,24 @@ To handle clusters split across multiple releases, you should:
 
 This ensures that all instances are using the new Kong package before running kong migrations finish.
 
-## Migrate databases for Upgrades {#migrate-db}
+### Migrating databases for Upgrades {#migrate-db}
 
-Kong Gateway supports the zero downtime migration model. This means
+{{site.ee_product_name}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two Kong clusters with different
 versions running that are sharing the same database. This is sometimes referred
 to as the
 [blue-green migration model](https://en.wikipedia.org/wiki/Blue-green_deployment).
 
 The migrations are designed so that there is no need to fully copy
-the data. The new version of Kong Gateway is able to use the data as it
+the data. The new version of {{site.ee_product_name}} is able to use the data as it
 is migrated, and the old Kong cluster keeps working until it is finally time to
 decommission it. For this reason, the full migration is split into two commands:
 
 - `kong migrations up`: performs only non-destructive operations
 - `kong migrations finish`: puts the database in the final expected state (DB-less
-  mode is not supported in Kong Gateway)
+  mode is not supported in {{site.ee_product_name}})
 
-### Postgres
+#### Postgres
 
 1. Download 2.6.x, and configure it to point to the same datastore as your old
    2.5.x (or 2.6.x-beta) cluster.
@@ -221,14 +175,14 @@ decommission it. For this reason, the full migration is split into two commands:
    old 2.5.x (or 2.6.x-beta) nodes.
 6. From your 2.6.x cluster, run `kong migrations finish`. From this point onward,
    it is no longer possible to start nodes in the old 2.5.x (or 2.6.x-beta) cluster
-   that still points to the same datastore. Run this command _only_ when you're
+   that still points to the same datastore. Run this command _only_ when you are
    confident that your migration was successful. From now on, you can safely make
    Admin API requests to your 2.6.x nodes.
 
-### Cassandra
+#### Cassandra
 
-Due to internal changes, the table schemas used by Kong Gateway 2.6.x on Cassandra
-are incompatible with those used by Kong Gateway 2.0.x. Migrating using the usual commands
+Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.6.x on Cassandra
+are incompatible with those used by {{site.ee_product_name}} 2.0.x. Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
 database at the same time. Alternatively, to keep your previous version fully
@@ -252,15 +206,15 @@ data to a new keyspace using a database dump, as described below:
 6. When your traffic is fully migrated to the 2.6.x cluster,
    decommission your old nodes.
 
-## Install Kong Gateway on a fresh datastore
+### Installing 2.6.x on a fresh datastore
 
-For installing on a fresh datastore, Kong Gateway 2.6.x has the
+For installing on a fresh datastore, {{site.ee_product_name}} 2.6.x has the
 `kong migrations bootstrap` command. Run the following commands to
 prepare a new 2.6.x cluster from a fresh datastore. By default, the `kong` CLI tool
 loads the configuration from `/etc/kong/kong.conf`, but you can optionally use
 the `-c` flag to indicate the path to your configuration file:
 
 ```bash
-kong migrations bootstrap [-c /path/to/kong.conf]
-kong start [-c /path/to/kong.conf]
+$ kong migrations bootstrap [-c /path/to/kong.conf]
+$ kong start [-c /path/to/kong.conf]
 ```

--- a/app/gateway/2.6.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-oss.md
@@ -1,0 +1,166 @@
+---
+# Generated via autodoc/upgrading/generate.lua in the kong/kong repo
+title: Upgrade Kong Gateway OSS
+---
+
+This document guides you through the process of upgrading {{site.ce_product_name}} to the **latest version**.
+To upgrade to prior versions, find the version number in the
+[Upgrade doc in GitHub](https://github.com/Kong/kong/blob/master/UPGRADE.md).
+
+## Upgrade to `2.6.x`
+
+Kong adheres to [semantic versioning](https://semver.org/), which makes a
+distinction between "major", "minor", and "patch" versions. The upgrade path
+will be different depending on which previous version from which you are migrating.
+
+If you are migrating from 2.0.x, 2.1.x, 2.2.x or 2.3.x, 2.4.x or 2.5.x into 2.6.x is a
+minor upgrade, but read below for important instructions on database migration,
+especially for Cassandra users.
+
+If you are migrating from 1.x, upgrading into 2.6.x is a major upgrade,
+so, in addition, be aware of any [breaking changes](https://github.com/Kong/kong/blob/master/UPGRADE.md#breaking-changes-2.0)
+between the 1.x and 2.x series below, further detailed in the
+[CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md#200) document.
+
+
+### Dependencies
+
+If you are using the provided binary packages, all necessary dependencies
+for the gateway are bundled and you can skip this section.
+
+If you are building your dependencies by hand, there are changes since the
+previous release, so you will need to rebuild them with the latest patches.
+
+The required OpenResty version for kong 2.6.x is
+[1.19.9.1](https://openresty.org/en/changelog-1019003.html). This is more recent
+than the version in Kong 2.5.0 (which used `1.19.3.2`). In addition to an upgraded
+OpenResty, you will need the correct [OpenResty patches](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools/openresty-patches)
+for this new version, including the latest release of [lua-kong-nginx-module](https://github.com/Kong/lua-kong-nginx-module).
+The [kong-build-tools](https://github.com/Kong/kong-build-tools)
+repository contains [openresty-build-tools](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools),
+which allows you to more easily build OpenResty with the necessary patches and modules.
+
+There is a new way to deploy Go using Plugin Servers.
+For more information, see [Developing Go plugins](https://docs.konghq.com/gateway-oss/2.6.x/external-plugins/#developing-go-plugins).
+
+### Template changes
+
+There are **Changes in the Nginx configuration file**, between kong 2.0.x,
+2.1.x, 2.2.x, 2.3.x, 2.4.x and 2.5.x.
+
+To view the configuration changes between versions, clone the
+[Kong repository](https://github.com/kong/kong) and run `git diff`
+on the configuration templates, using `-w` for greater readability.
+
+Here's how to see the differences between previous versions and 2.6.x:
+
+```
+git clone https://github.com/kong/kong
+cd kong
+git diff -w 2.0.0 2.6.0 kong/templates/nginx_kong*.lua
+```
+
+**Note:** Adjust the starting version number
+(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you are currently using.
+
+To produce a patch file, use the following command:
+
+```
+git diff 2.0.0 2.6.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
+```
+
+**Note:** Adjust the starting version number
+(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you are currently using.
+
+
+### Suggested upgrade path
+
+**Version prerequisites for migrating to version 2.6.x**
+
+The lowest version that Kong 2.6.x supports migrating from is 1.0.x.
+If you are migrating from a version lower than 0.14.1, you need to
+migrate to 0.14.1 first. Then, once you are migrating from 0.14.1,
+please migrate to 1.5.x first.
+
+The steps for upgrading from 0.14.1 to 1.5.x are the same as upgrading
+from 0.14.1 to Kong 1.0. Please follow the steps described in the
+"Migration Steps from 0.14" in the
+
+[Suggested Upgrade Path for Kong 1.0](https://github.com/Kong/kong/blob/master/UPGRADE.md#kong-1-0-upgrade-path)
+with the addition of the `kong migrations migrate-apis` command,
+which you can use to migrate legacy `apis` configurations.
+
+Once you migrated to 1.5.x, you can follow the instructions in the section
+below to migrate to 2.6.x.
+
+### Upgrade from `1.0.x` - `2.2.x` to `2.6.x`
+
+**Postgres**
+
+Kong 2.6.x supports a no-downtime migration model. This means that while the
+migration is ongoing, you will have two Kong clusters running, sharing the
+same database. (This is sometimes called the Blue/Green migration model.)
+
+The migrations are designed so that the new version of Kong is able to use
+the database as it is migrated while the old Kong cluster keeps working until
+it is time to decommission it. For this reason, the migration is split into
+two steps, performed via commands `kong migrations up` (which does
+only non-destructive operations) and `kong migrations finish` (which puts the
+database in the final expected state for Kong 2.6.x).
+
+1. Download 2.6.x, and configure it to point to the same datastore
+   as your old (1.0 to 2.0) cluster. Run `kong migrations up`.
+2. After that finishes running, both the old (2.x.x) and new (2.6.x)
+   clusters can now run simultaneously. Start provisioning 2.6.x nodes,
+   but do not use their Admin API yet. If you need to perform Admin API
+   requests, these should be made to the old cluster's nodes. The reason
+   is to prevent the new cluster from generating data that is not understood
+   by the old cluster.
+3. Gradually divert traffic away from your old nodes, and into
+   your 2.6.x cluster. Monitor your traffic to make sure everything
+   is going smoothly.
+4. When your traffic is fully migrated to the 2.6.x cluster,
+   decommission your old nodes.
+5. From your 2.6.x cluster, run: `kong migrations finish`.
+   From this point on, it will not be possible to start
+   nodes in the old cluster pointing to the same datastore anymore. Only run
+   this command when you are confident that your migration
+   was successful. From now on, you can safely make Admin API
+   requests to your 2.6.x nodes.
+
+**Cassandra**
+
+Due to internal changes, the table schemas used by Kong 2.6.x on Cassandra
+are incompatible with those used by Kong 2.1.x (or lower). Migrating using the usual commands
+`kong migrations up` and `kong migrations finish` will require a small
+window of downtime, since the old and new versions cannot use the
+database at the same time. Alternatively, to keep your previous version fully
+operational while the new one initializes, you will need to transfer the
+data to a new keyspace via a database dump, as described below:
+
+1. Download 2.6.x, and configure it to point to a new keyspace.
+   Run `kong migrations bootstrap`.
+2. Once that finishes running, both the old (pre-2.1) and new (2.6.x)
+   clusters can now run simultaneously, but the new cluster does not
+   have any data yet.
+3. On the old cluster, run `kong config db_export`. This will create
+   a file `kong.yml` with a database dump.
+4. Transfer the file to the new cluster and run
+   `kong config db_import kong.yml`. This will load the data into the new cluster.
+5. Gradually divert traffic away from your old nodes, and into
+   your 2.6.x cluster. Monitor your traffic to make sure everything
+   is going smoothly.
+6. When your traffic is fully migrated to the 2.6.x cluster,
+   decommission your old nodes.
+
+### Installing 2.6.x on a fresh datastore
+
+The following commands should be used to prepare a new 2.6.x cluster from a
+fresh datastore. By default the `kong` CLI tool will load the configuration
+from `/etc/kong/kong.conf`, but you can optionally use the flag `-c` to
+indicate the path to your configuration file:
+
+```
+kong migrations bootstrap [-c /path/to/your/kong.conf]
+kong start [-c /path/to/your/kong.conf]
+```

--- a/app/gateway/2.6.x/install-and-run/upgrade.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade.md
@@ -25,7 +25,7 @@ instructions on [database migration](#migrate-db), especially for Cassandra user
 - Upgrading from from 1.x is a major upgrade. Follow the [Version Prerequisites](#version-prerequisites).
 Be aware of any noted breaking changes as documented in the version to which you are upgrading.
 
-### Version Prerequisites
+### Version prerequisites
 
 If you are not on Kong Gateway 2.5.x, you must first incrementally
 upgrade to 2.5.x before upgrading to 2.6.x. Zero downtime is possible but _not_

--- a/app/gateway/2.6.x/install-and-run/upgrade.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade.md
@@ -3,11 +3,11 @@ title: Upgrade Guide
 toc: true
 ---
 
-Upgrade to major, minor, and patch {{site.ee_product_name}} releases using the
+Upgrade to major, minor, and patch Kong Gateway releases using the
 `kong migrations` commands.
 
 You can also use the commands to migrate all Kong Gateway OSS entities to Kong Gateway Enterprise. See
-[Migrating from Kong Gateway to Kong Enterprise](/enterprise/{{page.kong_version}}/deployment/upgrades/migrate-ce-to-ke/).
+[Migrating from Kong Gateway OSS to Kong Gateway Enterprise](/upgrades/migrate-ce-to-ke/).
 
 If you experience any issues when running migrations, contact
 [Kong Support](https://support.konghq.com/support/s/) for assistance.
@@ -31,6 +31,8 @@ If you are not on Kong Gateway 2.5.x, you must first incrementally
 upgrade to 2.5.x before upgrading to 2.6.x. Zero downtime is possible but _not_
 guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1.3.x to
 1.5.x to 2.1.x to 2.2.x to 2.3.x to 2.4.x to 2.5.x to 2.6.x., plan accordingly.
+
+#### Enterprise instructions
 
 * If running a version of Kong Gateway earlier than 1.5,
   [migrate to 1.5](/enterprise/1.5.x/deployment/migrations/) first.
@@ -70,7 +72,7 @@ for the gateway are bundled and you can skip this section.
 If you are building your dependencies by hand, there are changes since the
 previous release, so you will need to rebuild them with the latest patches.
 
-The required OpenResty version for kong 2.6.x is
+The required OpenResty version for Kong 2.6.x is
 [1.19.9.1](https://openresty.org/en/changelog-1019003.html). This is more recent
 than the version in Kong 2.5.0 (which used `1.19.3.2`). In addition to an upgraded
 OpenResty, you will need the correct [OpenResty patches](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools/openresty-patches)
@@ -83,7 +85,7 @@ There is a new way to deploy Go using Plugin Servers.
 For more information, see [Developing Go plugins](https://docs.konghq.com/gateway-oss/2.6.x/external-plugins/#developing-go-plugins).
 
 
-There are **Changes in the Nginx configuration file**, between kong 2.0.x,
+There are **Changes in the Nginx configuration file**, between Kong 2.0.x,
 2.1.x, 2.2.x, 2.3.x, 2.4.x and 2.5.x.
 
 To view the configuration changes between versions, clone the
@@ -93,7 +95,7 @@ on the configuration templates, using `-w` for greater readability.
 Here's how to see the differences between previous versions and 2.6.x:
 
 ```bash
-git clone https://github.com/kong/kong
+git clone https://github.com/Kong/kong
 cd kong
 git diff -w 2.0.0 2.6.0 kong/templates/nginx_kong*.lua
 ```

--- a/app/gateway/2.6.x/install-and-run/upgrade.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade.md
@@ -27,7 +27,7 @@ Be aware of any noted breaking changes as documented in the version to which you
 
 ### Version prerequisites
 
-If you are not on Kong Gateway 2.5.x, you must first incrementally
+If you're not on Kong Gateway 2.5.x, you must first incrementally
 upgrade to 2.5.x before upgrading to 2.6.x. Zero downtime is possible but _not_
 guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1.3.x to
 1.5.x to 2.1.x to 2.2.x to 2.3.x to 2.4.x to 2.5.x to 2.6.x., plan accordingly.
@@ -52,7 +52,7 @@ guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1
 There are no migrations necessary for the Dev Portal when upgrading from 2.5.x to
 2.6.x.
 
-If you are currently using the Developer Portal in 1.5.x, it will no longer work without
+If you're currently using the Dev Portal in 1.5.x, it will no longer work without
 [manually migrating files](/enterprise/2.1.x/developer-portal/latest-migrations) to version 2.1.x.
 
 ## Upgrade considerations
@@ -66,10 +66,10 @@ affect your current installation.
 
 ### Dependencies
 
-If you are using the provided binary packages, all necessary dependencies
+If you're using the provided binary packages, all necessary dependencies
 for the gateway are bundled and you can skip this section.
 
-If you are building your dependencies by hand, there are changes since the
+If you're building your dependencies by hand, there are changes since the
 previous release, so you will need to rebuild them with the latest patches.
 
 The required OpenResty version for Kong 2.6.x is
@@ -101,7 +101,7 @@ git diff -w 2.0.0 2.6.0 kong/templates/nginx_kong*.lua
 ```
 
 **Note:** Adjust the starting version number
-(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you are currently using.
+(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you're currently using.
 
 To produce a patch file, use the following command:
 
@@ -110,15 +110,15 @@ git diff 2.0.0 2.6.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
 ```
 
 **Note:** Adjust the starting version number
-(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you are currently using.
+(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x or 2.5.x) to the version number you're currently using.
 
 ### Hybrid mode considerations
 
 {:.important}
-> **Important:** If you are currently running in [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
+> **Important:** If you're currently running in [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
 upgrade the Control Plane first, and then the Data Planes.
 
-* If you are currently running 2.6.x in classic (traditional)
+* If you're currently running 2.6.x in classic (traditional)
   mode and want to run in hybrid mode instead, follow the hybrid mode
   [installation instructions](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)
   after running the migration.
@@ -137,7 +137,7 @@ traffic and old pods are terminated. Once this is complete, the chart spawns ano
 to run `kong migrations finish`.
 
 While the migrations themselves are automated, the chart does not automatically ensure 
-that you follow the recommended upgrade path. If you are upgrading from more than one minor 
+that you follow the recommended upgrade path. If you're upgrading from more than one minor 
 Kong version back, check the upgrade path recommendations for Kong open source or Kong Gateway.
 
 Although not required, users should upgrade their chart version and Kong version independently. 
@@ -221,7 +221,7 @@ decommission it. For this reason, the full migration is split into two commands:
    old 2.5.x (or 2.6.x-beta) nodes.
 6. From your 2.6.x cluster, run `kong migrations finish`. From this point onward,
    it is no longer possible to start nodes in the old 2.5.x (or 2.6.x-beta) cluster
-   that still points to the same datastore. Run this command _only_ when you are
+   that still points to the same datastore. Run this command _only_ when you're
    confident that your migration was successful. From now on, you can safely make
    Admin API requests to your 2.6.x nodes.
 


### PR DESCRIPTION
Update language on Upgrade guide. For now, I have added a section that calls out that the migration links are for Enterprise. Where are the OSS links, if we have migration guides for OSS?

@lena-larionova this brings up a question for the links. Are we keeping the `enterprise` and `gateway-oss` folders? 

