### PR TITLE
[DOCU-1911] Badges and links

### DIFF
--- a/app/gateway/2.6.x/admin-api/admins/examples.md
+++ b/app/gateway/2.6.x/admin-api/admins/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Admins Examples
-book: admins
+badge: free
 ---
 
 ## How to Invite and Register an Admin

--- a/app/gateway/2.6.x/admin-api/admins/reference.md
+++ b/app/gateway/2.6.x/admin-api/admins/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Admins Reference
-book: admins
+badge: free
 ---
 
 ## List Admins
@@ -128,10 +128,10 @@ HTTP 200 OK
 | `name_or_id` | The **Admin**'s username or ID |
 | `generate_register_url` <br>optional | `true` returns a unique registration URL for the **Admin** |
 
-**Notes:** 
-* `generate_register_url` will only generate a URL if the **Admin**'s 
+**Notes:**
+* `generate_register_url` will only generate a URL if the **Admin**'s
 invitation status is 4 ("invited").
-* `generate_register_url` will override the preåvious registration URL 
+* `generate_register_url` will override the preåvious registration URL
 for the particular **Admin** each time it is requested.
 
 **Response**

--- a/app/gateway/2.6.x/admin-api/audit-log.md
+++ b/app/gateway/2.6.x/admin-api/audit-log.md
@@ -1,14 +1,13 @@
 ---
 title: Admin API Audit Log
+badge: enterprise
 ---
-
-## Introduction
 
 Kong Enterprise provides a granular logging facility on its Admin API. This
 allows cluster administrators to keep detailed track of changes made to the
 cluster configuration throughout its lifetime, aiding in compliance efforts and
 providing valuable data points during forensic investigations. Generated audit
-log trails are [Workspace](/enterprise/{{page.kong_version}}/admin-api/workspaces/reference) and [RBAC](/enterprise/{{page.kong_version}}/admin-api/rbac/reference)-aware,
+log trails are [Workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference) and [RBAC](/gateway/{{page.kong_version}}/admin-api/rbac/reference)-aware,
 providing Kong operators a deep and wide look into changes happening within
 the cluster.
 
@@ -183,7 +182,7 @@ The following request paths generate an audit log entry in the database:
 ### Audit Log Retention
 
 Request audit records are kept in the database for a duration defined by the
-`audit_log_record_ttl` [Kong configuration property](https://docs.konghq.com/enterprise/{{page.kong_version}}/property-reference/#audit_log_record_ttl).
+`audit_log_record_ttl` [Kong configuration property](/gateway/{{page.kong_version}}/reference/property-reference/#audit_log_record_ttl).
 Records in the database older than `audit_log_record_ttl` seconds are automatically
 purged. In Cassandra databases, record deletion is handled automatically via the
 Cassandra TTL mechanism. In Postgres databases, records are purged via the stored
@@ -304,7 +303,7 @@ audit_log_ignore_tables = consumers
 ### Audit Log Retention
 
 Database audit records are kept in the database for a duration defined by the
-`audit_log_record_ttl` [Kong configuration property](https://docs.konghq.com/enterprise/{{page.kong_version}}/property-reference/#audit_log_record_ttl).
+`audit_log_record_ttl` [Kong configuration property](/gateway/{{page.kong_version}}/reference/property-reference/#audit_log_record_ttl).
 Records in the database older than `audit_log_record_ttl` seconds are automatically
 purged. In Cassandra databases, record deletion is handled automatically via the
 Cassandra TTL mechanism. In Postgres databases, records are purged via the stored
@@ -494,5 +493,5 @@ HTTP 200 OK
 
 ### Configuration Reference
 
-See the [Data & Admin Audit](/enterprise/{{page.kong_version}}/property-reference#data--admin-audit)
+See the [Data & Admin Audit](/gateway/{{page.kong_version}}/property-reference#data--admin-audit)
 section of Kong Enterprise's Configuration Property Reference.

--- a/app/gateway/2.6.x/admin-api/db-encryption.md
+++ b/app/gateway/2.6.x/admin-api/db-encryption.md
@@ -1,5 +1,6 @@
 ---
 title: Keyring & Data Encryption
+badge: enterprise
 ---
 
 ## View Keyring

--- a/app/gateway/2.6.x/admin-api/event-hooks/examples.md
+++ b/app/gateway/2.6.x/admin-api/event-hooks/examples.md
@@ -1,9 +1,7 @@
 ---
 title: Event Hooks Examples
-book: event-hooks
+badge: enterprise
 ---
-
-## Introduction
 
 {% include /md/enterprise/event-hooks-intro.md %}
 
@@ -105,7 +103,7 @@ username="Ada Lovelace"</code></pre><div>
 Custom webhook event hooks are fully customizable requests. Custom webhooks are useful for building direct
 integration with a service. Because custom webhooks are fully configurable, they have more complex configurations.
 Custom webhooks support Lua templating on a configurable body, form payload, and headers. For a list of
-possible fields for templating, see the [sources](/enterprise/{{ page.kong_version }}/admin-api/event-hooks/reference/#list-all-sources) endpoint.
+possible fields for templating, see the [sources](/gateway/{{ page.kong_version }}/admin-api/event-hooks/reference/#list-all-sources) endpoint.
 
 The following example sends a message to Slack any time a new administrator is invited to Kong Gateway.
 Slack allows for [incoming webhooks](https://slack.com/help/articles/115005265063-Incoming-webhooks-for-Slack#set-up-incoming-webhooks)
@@ -304,7 +302,7 @@ any time a consumer changes, but conditionally and with custom formatting.
 
 {:.important}
 > The lambda event hook type is extremely powerful: you can write completely custom logic to handle any use case you want.
-However, it’s [restricted by default through the sandbox.](/enterprise/{{ page.kong_version }}/property-reference/#untrusted_lua).  This
+However, it’s [restricted by default through the sandbox.](/gateway/{{ page.kong_version }}/reference/property-reference/#untrusted_lua).  This
 sandbox is put in place to keep users safe: it’s easy to inadvertently add unsafe libraries/objects into the sandbox
 and leave the Kong Gateway exposed to security vulnerabilities. Use caution before modifying these sandbox settings.
 

--- a/app/gateway/2.6.x/admin-api/event-hooks/reference.md
+++ b/app/gateway/2.6.x/admin-api/event-hooks/reference.md
@@ -1,9 +1,7 @@
 ---
 title: Event Hooks Reference
-book: event-hooks
+badge: enterprise
 ---
-
-## Introduction
 
 {:.important}
 > **Important:** Before you can use event hooks for the first time, Kong needs to be
@@ -154,7 +152,7 @@ The ellipsis in the center of the response represents the missing content.
 ## List all events for a source
 
 Events are the Kong entities the event hook will listen to for events. With this endpoint you
-can list all of the events associated with a particular source. 
+can list all of the events associated with a particular source.
 
 <div class="endpoint get">/event-hooks/sources/{source}/</div>
 
@@ -365,7 +363,7 @@ POST any data to `/event-hooks/:id-of-hook/test`, and the `/test` endpoint execu
 
 **Endpoint**
 
-<div class="endpoint post">/event-hooks/{event-hook-id}/test</div> 
+<div class="endpoint post">/event-hooks/{event-hook-id}/test</div>
 
 **Response**
 

--- a/app/gateway/2.6.x/admin-api/index.md
+++ b/app/gateway/2.6.x/admin-api/index.md
@@ -20,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -92,21 +92,21 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route. Name values must be unique.
     `protocols` |  An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route. Note that the hosts value is case sensitive.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path` |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host` |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
+    `preserve_host` |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
     `request_buffering` |  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.  Default: `true`.
     `response_buffering` |  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.  Default: `true`.
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -174,9 +174,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -205,15 +205,15 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `run_on`<br>*optional* (Enterprise only) |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled` | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -259,10 +259,10 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. 
-    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it.
+    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it.
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
     `passphrase`<br>*optional* (Enterprise only) | To load an encrypted private key into Kong, specify the passphrase using this attribute. Kong will decrypt the private key and store it in its database. To encrypt the private key and other sensitive information in Kong's database, consider using DB encryption.
 
 
@@ -301,7 +301,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -331,7 +331,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -392,7 +392,7 @@ upstream_body: |
     `healthchecks.active.`<wbr>`unhealthy.interval`<br>*optional* | Interval between active health checks for unhealthy targets (in seconds). A value of zero indicates that active probes for unhealthy targets should not be performed. Default: `0`.
     `healthchecks.active.`<wbr>`unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in active probes to consider a target unhealthy. Default: `0`.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -549,9 +549,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {
@@ -4179,9 +4179,9 @@ HTTP 200 OK
 
 ---
 
-[clustering]: /gateway-oss/{{page.kong_version}}/clustering
-[cli]: /gateway-oss/{{page.kong_version}}/cli
-[active]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
-[healthchecks]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers
-[secure-admin-api]: /gateway-oss/{{page.kong_version}}/secure-admin-api
-[proxy-reference]: /gateway-oss/{{page.kong_version}}/proxy
+[clustering]: /gateway/{{page.kong_version}}/reference/clustering
+[cli]: /gateway/{{page.kong_version}}/reference/cli
+[active]: /gateway/{{page.kong_version}}/reference/health-checks-circuit-breakers/#active-health-checks
+[healthchecks]: /gateway/{{page.kong_version}}/reference/health-checks-circuit-breakers
+[secure-admin-api]: /gateway/{{page.kong_version}}/admin-api/secure-admin-api
+[proxy-reference]: /gateway/{{page.kong_version}}/reference/proxy

--- a/app/gateway/2.6.x/admin-api/licenses/examples.md
+++ b/app/gateway/2.6.x/admin-api/licenses/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Licenses Examples
-book: licenses
+badge: enterprise
 ---
 <div class="alert alert-ee">
 <b>Note:</b> The <code>/licenses</code> endpoint does not override standard
@@ -139,4 +139,4 @@ Response:
 }
 ```
 
-[services]: /enterprise/{{page.kong_version}}/admin-api/#service-object
+[services]: /gateway/{{page.kong_version}}/admin-api/#service-object

--- a/app/gateway/2.6.x/admin-api/licenses/reference.md
+++ b/app/gateway/2.6.x/admin-api/licenses/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Licenses Reference
-book: licenses
+badge: enterprise
 
 licenses_attribute_id: |
     Attributes | Description
@@ -12,8 +12,6 @@ licenses_body: |
     ---:| ---
     `payload` | The **Kong Gateway license** in JSON format.
 ---
-
-## Introduction
 
 The {{site.base_gateway}} Licenses feature is configurable through the
 [Admin API]. This feature lets you configure a license in your
@@ -200,4 +198,4 @@ HTTP 200 OK
 HTTP 204 No Content
 ```
 
-[Admin API]: /enterprise/{{page.kong_version}}/admin-api/
+[Admin API]: /gateway/{{page.kong_version}}/admin-api/

--- a/app/gateway/2.6.x/admin-api/rbac/examples.md
+++ b/app/gateway/2.6.x/admin-api/rbac/examples.md
@@ -1,9 +1,7 @@
 ---
 title: RBAC Examples
-book: rbac
+badge: free
 ---
-
-## Introduction
 
 This chapter aims to provide a step-by-step tutorial on how to set up
 RBAC and see it in action, with an end-to-end use case. The chosen
@@ -1042,7 +1040,7 @@ he created.
 
 ---
 
-[rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
-[rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
-[workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
-[getting-started-guide]: /getting-started-guide/latest/overview
+[rbac-overview]: /gateway/{{page.kong_version}}/configure/auth/rbac
+[rbac-admin]: /gateway/{{page.kong_version}}/admin-api/rbac/reference
+[workspaces-examples]: /gateway/{{page.kong_version}}/admin-api/workspaces/examples
+[getting-started-guide]: /gateway/{{page.kong_version}}/get-started/comprehensive

--- a/app/gateway/2.6.x/admin-api/rbac/reference.md
+++ b/app/gateway/2.6.x/admin-api/rbac/reference.md
@@ -1,12 +1,10 @@
 ---
 title: RBAC Reference
-book: rbac
+badge: free
 ---
 
-## Introduction
-
-Kong Enterprise's RBAC feature is configurable through Kong's [Admin
-API](/enterprise/{{page.kong_version}}/admin-api/) or via the [Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/overview/).
+Kong Enterprise's RBAC feature is configurable through Kong's
+[Admin API](/gateway/{{page.kong_version}}/admin-api/) or via the [Kong Manager](/gateway/{{page.kong_version}}/configure/auth/rbac).
 
 There are 4 basic entities involving RBAC.
 
@@ -124,7 +122,7 @@ HTTP 200 OK
 
 ⚠️ **Note**: **RBAC Users** associated with **Admins** will _not_ be
 listed with **`GET`** `/rbac/users`. Instead, use
-[**`GET`** `/admins`](/enterprise/{{page.kong_version}}/admin-api/admins/reference/#list-admins)
+[**`GET`** `/admins`](/gateway/{{page.kong_version}}/admin-api/admins/reference/#list-admins)
 to list all **Admins**.
 
 ___

--- a/app/gateway/2.6.x/admin-api/secure-admin-api.md
+++ b/app/gateway/2.6.x/admin-api/secure-admin-api.md
@@ -1,8 +1,7 @@
 ---
 title: Securing the Admin API
+badge: enterprise
 ---
-
-## Introduction
 
 Kong's Admin API provides a RESTful interface for administration and
 configuration of Services, Routes, Plugins, Consumers, and Credentials. Because this
@@ -247,6 +246,6 @@ Enterprise offering by [contacting us](/enterprise).
 
 [acl]: /hub/kong-inc/acl
 [basic-auth]: /hub/kong-inc/basic-auth
-[custom-configuration]: /enterprise/{{page.kong_version}}/property-reference/#custom-nginx-configuration
+[custom-configuration]: /gateway/{{page.kong_version}}/reference/property-reference/#custom-nginx-configuration
 [ip-restriction]: /hub/kong-inc/ip-restriction
 [key-auth]: /hub/kong-inc/key-auth

--- a/app/gateway/2.6.x/admin-api/workspaces/examples.md
+++ b/app/gateway/2.6.x/admin-api/workspaces/examples.md
@@ -1,9 +1,7 @@
 ---
 title: Workspace Examples
-book: workspaces
+badge: free
 ---
-
-## Introduction
 
 This chapter aims to provide a step-by-step tutorial on how to set up
 workspaces, entities, and see it in action.
@@ -187,4 +185,4 @@ operation that is allowed in the non-workspaced Kong world.
 
 ---
 
-[services]: /enterprise/{{page.kong_version}}/admin-api/#service-object
+[services]: /gateway/{{page.kong_version}}/admin-api/#service-object

--- a/app/gateway/2.6.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.6.x/admin-api/workspaces/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Workspaces Reference
-book: workspaces
+badge: free
 
 workspace_body: |
     Attribute | Description
@@ -8,10 +8,9 @@ workspace_body: |
     `name` | The **Workspace** name.
 ---
 
-## Introduction
 
 Kong Enterprise's Workspaces feature is configurable through Kong's
-[Admin API].
+Admin API.
 
 ## Workspace Object
 
@@ -351,4 +350,4 @@ HTTP 200 OK
 ```
 ---
 
-[Admin API]: /enterprise/{{page.kong_version}}/admin-api/
+[Admin API]: /gateway/{{page.kong_version}}/admin-api/

--- a/app/gateway/2.6.x/configure/auth/allowing-multiple-authentication-methods.md
+++ b/app/gateway/2.6.x/configure/auth/allowing-multiple-authentication-methods.md
@@ -7,7 +7,7 @@ for all requests without regard for whether a request has been authenticated
 via some other plugin. Configuring an anonymous consumer on your authentication
 plugins allows you to offer clients multiple options for authentication.
 
-To begin, [create a Service](/enterprise/{{page.kong_version}}/kong-manager/add-service/) and then create three consumers:
+To begin, [create a Service](/gateway/{{page.kong_version}}/admin-api/#service-object) and then create three consumers:
 
 ```bash
 $ curl -sX POST kong-admin:8001/consumers \

--- a/app/gateway/2.6.x/configure/auth/index.md
+++ b/app/gateway/2.6.x/configure/auth/index.md
@@ -2,8 +2,6 @@
 title: Authentication Reference
 ---
 
-## Introduction
-
 Traffic to your Upstream services (APIs or microservices) is typically controlled by the application and
 configuration of various Kong [authentication plugins][plugins]. Because Kong's Service entity represents
 a 1-to-1 mapping of your own upstream services, the simplest scenario is to configure authentication

--- a/app/gateway/2.6.x/configure/auth/kong-manager/basic.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/basic.md
@@ -18,7 +18,7 @@ The **Sessions Plugin** requries a secret and is configured securely by default.
 * Under all circumstances, the `secret` must be manually set to a string.
 * If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
-Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#example-configurations).
 
 ## Step 1
 
@@ -36,6 +36,6 @@ set in the environment variable.
 
 If you created a Super Admin via the Kong Manager "Organization" tab
 as described in
-[How to Create a Super Admin](/enterprise/{{page.kong_version}}/kong-manager/authentication/super-admin),
+[How to Create a Super Admin](/gateway/{{page.kong_version}}/configure/auth/kong-manager/super-admin),
 log in with the credentials you created after accepting the email
 invitation.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/email.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/email.md
@@ -9,9 +9,9 @@ workflows use email to communicate with the user.
 
 Emails from Kong Manager require the following configuration:
 
-* [`admin_emails_from`](/enterprise/{{page.kong_version}}/property-reference/#admin_emails_from)
-* [`admin_emails_reply_to`](/enterprise/{{page.kong_version}}/property-reference/#admin_emails_reply_to)
-* [`admin_invitation_expiry`](/enterprise/{{page.kong_version}}/property-reference/#admin_invitation_expiry)
+* [`admin_emails_from`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_emails_from)
+* [`admin_emails_reply_to`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_emails_reply_to)
+* [`admin_invitation_expiry`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_invitation_expiry)
 
 Kong does not check for the validity of email
 addresses set in the configuration. If the SMTP settings are
@@ -19,5 +19,5 @@ configured incorrectly, e.g., if they point to a non-existent
 email address, Kong Manager will _not_ display an error message.
 
 For additional information about SMTP, refer to the
-[general SMTP configuration](/enterprise/{{page.kong_version}}/property-reference/#general-smtp-configuration)
+[general SMTP configuration](/gateway/{{page.kong_version}}/reference/property-reference/#general-smtp-configuration)
 shared by Kong Manager and Dev Portal.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/index.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/index.md
@@ -22,12 +22,12 @@ if needed.
 
 Kong Manager currently supports the following **Authentication Plugins**:
 
-* [**Basic Auth**](/enterprise/{{page.kong_version}}/kong-manager/authentication/basic/)
-* [**OIDC**](/enterprise/{{page.kong_version}}/kong-manager/authentication/oidc/)
-* [**LDAP**](/enterprise/{{page.kong_version}}/kong-manager/authentication/ldap/)
+* [**Basic Auth**](/gateway/{{page.kong_version}}/configure/auth/kong-manager/basic/)
+* [**OIDC**](/gateway/{{page.kong_version}}/configure/auth/kong-manager/oidc/)
+* [**LDAP**](/gateway/{{page.kong_version}}/configure/auth/kong-manager/ldap/)
 
 In addition to the **Authentication Plugins** above, the new
-[**Sessions Plugin**](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/)
+[**Sessions Plugin**](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/)
 is now required when RBAC is enabled. It sends HTTP cookies to authenticate
 client requests and maintain session information.
 
@@ -38,8 +38,8 @@ securely by default.
 * If using different domains for the Admin API and Kong Manager,
 `cookie_samesite` must be set to `off`.
 Learn more about these properties in
-[Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security),
-and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+[Session Security in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#session-security),
+and see [example configurations](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#example-configurations).
 
 ## Access Control with Roles and Workspaces
 
@@ -48,12 +48,12 @@ with a set of **Permissions**. If an **Admin** is in a **Workspace** *without*
 a **Role**, they will not have the ability to see or interact with anything.
 
 By creating separate
-[**Workspaces**](/enterprise/{{page.kong_version}}/kong-manager/administration/workspaces/workspaces/),
+[**Workspaces**](/gateway/{{page.kong_version}}/configure/auth/kong-manager/workspaces/),
  an organization with multiple teams can segment its Kong cluster so that
  different teams do not have access to each other's Kong entities.
 
 Kong Enterprise implements Role-Based Access Control
-([RBAC](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac/)).
+([RBAC](/gateway/{{page.kong_version}}/configure/auth/rbac)).
 **Admins** are assigned **Roles** that have clearly defined **Permissions**. A
 **Super Admin** has the ability to:
 
@@ -65,4 +65,4 @@ Kong Enterprise implements Role-Based Access Control
 In Kong Manager, limiting **Permissions** also restricts the visibility of the
 application interface and navigation. Learn more about RBAC in Kong Manager in
 our guide
-[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac).
+[RBAC in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/rbac/).

--- a/app/gateway/2.6.x/configure/auth/kong-manager/ldap.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/ldap.md
@@ -56,7 +56,7 @@ The **Sessions Plugin** requries a secret and is configured securely by default.
 * Under all circumstances, the `secret` must be manually set to a string.
 * If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
-Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#example-configurations).
 
 After starting Kong with the desired configuration, you can create new *Admins*
 whose usernames match those in the AD. Those users will then be able to accept

--- a/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
@@ -7,7 +7,7 @@ badge: free
 
 By default, Kong Manager starts up without authentication (see
 [`admin_gui_auth`]), and it assumes that the Admin API is available
-on port 8001 (see [Default Ports](/enterprise/{{page.kong_version}}/deployment/default-ports) of the same host that serves
+on port 8001 (see [Default Ports](/gateway/{{page.kong_version}}/plan-and-deploy/default-ports) of the same host that serves
 Kong Manager.
 
 ## Custom Configuration
@@ -93,12 +93,12 @@ is cleared from the browser after testing to prevent stale certificates from int
 `localhost`.
 
 
-[`admin_gui_auth`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_auth
-[`admin_gui_ssl_cert`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_ssl_cert
-[`admin_gui_ssl_cert_key`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_ssl_cert_key
-[`default_ports`]: /enterprise/{{page.kong_version}}/deployment/default-ports
-[`admin_api_uri`]: /enterprise/{{page.kong_version}}/property-reference/#admin_api_uri
-[`admin_gui_auth_conf`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_auth_conf
-[`enforce_rbac`]: /enterprise/{{page.kong_version}}/property-reference/#enforce_rbac
-[`admin_listen`]: /enterprise/{{page.kong_version}}/property-reference/#admin_listen
-[`admin_gui_session_conf`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_session_conf
+[`admin_gui_auth`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_auth
+[`admin_gui_ssl_cert`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_ssl_cert
+[`admin_gui_ssl_cert_key`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_ssl_cert_key
+[`default_ports`]: /gateway/{{page.kong_version}}/plan-and-deploy/default-ports
+[`admin_api_uri`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_api_uri
+[`admin_gui_auth_conf`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_auth_conf
+[`enforce_rbac`]: /gateway/{{page.kong_version}}/reference/property-reference/#enforce_rbac
+[`admin_listen`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_listen
+[`admin_gui_session_conf`]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_session_conf

--- a/app/gateway/2.6.x/configure/auth/kong-manager/oidc.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/oidc.md
@@ -47,7 +47,7 @@ The **Sessions Plugin** requries a secret and is configured securely by default.
 * Under all circumstances, the `secret` must be manually set to a string.
 * If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
-Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#example-configurations).
 
 Replace the entries surrounded by `<>` with values that are valid for your IdP.
 For example, Google credentials can be found here:

--- a/app/gateway/2.6.x/configure/auth/kong-manager/reset-password.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/reset-password.md
@@ -36,7 +36,7 @@ Prerequisites:
 
 * `enforce_rbac = on`
 * `admin_gui_auth = basic-auth`
-* [`admin_gui_session_conf` is configured](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/).
+* [`admin_gui_session_conf` is configured](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/).
 * Already logged in to Kong Manager
 
 Steps:
@@ -49,8 +49,8 @@ Steps:
 Prerequisites:
 
 * `enforce_rbac = on`
-* [`admin_gui_auth` is set](/enterprise/{{page.kong_version}}/kong-manager/security/#authentication-with-plugins).
-* [`admin_gui_session_conf` is configured](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/).
+* [`admin_gui_auth` is set](/gateway/{{page.kong_version}}/configure/auth/kong-manager/).
+* [`admin_gui_session_conf` is configured](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/).
 * Already logged in to Kong Manager
 
 Steps:

--- a/app/gateway/2.6.x/configure/auth/kong-manager/super-admin.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/super-admin.md
@@ -35,7 +35,7 @@ Manager on a node where `enforce_rbac` is set to `on` or `off`, but not `both`.
 
 In the event that the default `kong_admin`, **Super Admin**, was not seeded
 during the initial database preparation step as defined in
-[Step 1 in How To Start Kong Enterprise Securely](/enterprise/{{page.kong_version}}/start-kong-securely/#step-1),
+[How To Start Kong Enterprise Securely](/gateway/{{page.kong_version}}/plan-and-deploy/security/start-kong-securely/),
 the following steps outline how to create and enable a new Super Admin post
 installation.
 
@@ -44,7 +44,7 @@ account and generate a registration link.
 
 2. Before the link generated above can be used, RBAC and GUI Authentication must
 be enabled. Follow the instructions on
-[how to enable Basic Auth on Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/basic).
+[how to enable Basic Auth on Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/basic).
 
 3. Paste the URL in your browser and you will be asked to create a password for
 the newly defined **Super Admin** user on the Kong Manager.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
@@ -12,8 +12,8 @@ delimit the types of actions and entities available to an **Admin**.
 
 ## Prerequisites
 
-* [`enforce_rbac = on`](/enterprise/{{page.kong_version}}/property-reference/#enforce_rbac)
-* Kong Enterprise has [started](/enterprise/{{page.kong_version}}/start-kong-securely)
+* [`enforce_rbac = on`](/gateway/{{page.kong_version}}/reference/property-reference/#enforce_rbac)
+* Kong Enterprise has [started](/gateway/{{page.kong_version}}/plan-and-deploy/security/start-kong-securely)
 * Logged in to Kong Manager as a **Super Admin**
 
 ## Default Workspace
@@ -39,7 +39,7 @@ depending on preference.
 This guide describes how to create **Workspaces** in Kong
 Manager. As an alternative, if a **Super Admin** wants to create
 a **Workspace** with the Admin API, it is possible to do so
-using the [`/workspaces/` route](/enterprise/{{page.kong_version}}/admin-api/workspaces/reference/#add-workspace).
+using the [`/workspaces/` route](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#add-workspace).
 
 1. Log in as the **Super Admin**. On the **Workspaces** page, click the **New Workspace**
 button at the top right to see the **Create Workspace** form. Name and choose a
@@ -110,4 +110,4 @@ The **Admins** page displays a list of current **Admins** and
 to the **Workspace** can be assigned from this page.
 
 For more information about **Admins** and **Roles**, see
-[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/).
+[RBAC in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/rbac/).

--- a/app/gateway/2.6.x/configure/auth/oidc-auth0.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-auth0.md
@@ -3,8 +3,6 @@ title: OpenID Connect with Auth0
 badge: enterprise
 ---
 
-## Introduction
-
 This guide covers an example OpenID Connect plugin configuration to authenticate headless service consumers using Auth0's identity provider.
 
 ## Auth0 IDP Configuration
@@ -46,5 +44,5 @@ For basic authentication, use your client ID as the username and your client sec
 [client-credentials-grant]: https://auth0.com/docs/api-auth/tutorials/client-credentials
 [create-auth0-api]: https://auth0.com/docs/apis#how-to-configure-an-api-in-auth0
 [non-interactive-client]: https://auth0.com/docs/clients
-[add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
+[add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [audience-required]: https://auth0.com/docs/api/authentication#client-credentials

--- a/app/gateway/2.6.x/configure/auth/oidc-azuread.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-azuread.md
@@ -2,14 +2,13 @@
 title: OpenID Connect with Azure AD
 badge: enterprise
 ---
-## Introduction
 
 This guide covers an example OpenID Connect plugin configuration to authenticate
 browser clients using an Azure AD identity provider.
 
 For information about configuring OIDC using Azure as an Identity provider
 in conjunction with the Application Registration plugin, see
-[Set Up External Portal Application Authentication with Azure AD and OIDC](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
+[Set Up External Portal Application Authentication with Azure AD and OIDC](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
 
 ## Prerequisites
 
@@ -127,8 +126,8 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 [azure-create-app]: https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
 [azure-manifest]: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest#configure-the-app-manifest
 [azure-tenants]: https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps
-[add-certificate]: /1.2.x/admin-api/#add-certificate
-[add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
+[add-certificate]: /gateway/{{site.kong_version}}/admin-api/#add-certificate
+[add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [oidc-id-token]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
-[enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/
+[enable-plugin]: /gateway/{{page.kong_version}}/admin-api/#plugin-object

--- a/app/gateway/2.6.x/configure/auth/oidc-azuread.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-azuread.md
@@ -126,7 +126,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 [azure-create-app]: https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
 [azure-manifest]: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest#configure-the-app-manifest
 [azure-tenants]: https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps
-[add-certificate]: /gateway/{{site.kong_version}}/admin-api/#add-certificate
+[add-certificate]: /gateway/{{page.kong_version}}/admin-api/#add-certificate
 [add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [oidc-id-token]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim

--- a/app/gateway/2.6.x/configure/auth/oidc-curity.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-curity.md
@@ -203,11 +203,11 @@ select * from "accounts" where "username"= :subject
 
 With relatively simple configurations in both the Curity Identity Server and the Kong Developer Portal, it's possible to leverage Curity as the Identity Provider for the Kong Dev Portal. This provides a very seamless flow for user authentication to the Kong Dev Portal. With the added capability of an Authentication Action, it is possible to automatically provision the user to the Kong Dev Portal for an even more streamlined experience.
 
-[kong-add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
+[kong-add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [curity-phantom-token-introspection]: https://curity.io/resources/learn/introspect-with-phantom-token
 [curity-getting-started]: https://curity.io/resources/getting-started
 [curity-phantom-token-pattern]: https://curity.io/resources/learn/phantom-token-pattern
 [curity-code-flow-tutorial]: https://curity.io/resources/learn/code-flow
 [curity-kong-dev-portal-user-provisioner]: https://curity.io/resources/learn/provision-kong-dev-portal-user
-[kong-dev-portal-doc]: /enterprise/{{page.kong_version}}/developer-portal
-[kong-dev-portal-doc-oidc]: /enterprise/{{page.kong_version}}/developer-portal/configuration/authentication/oidc
+[kong-dev-portal-doc]: /gateway/{{page.kong_version}}/developer-portal
+[kong-dev-portal-doc-oidc]: /gateway/{{page.kong_version}}/developer-portal/configuration/authentication/oidc

--- a/app/gateway/2.6.x/configure/auth/oidc-google.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-google.md
@@ -58,7 +58,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /gateway/{{site.kong_version}}/admin-api/#add-certificate
+[add-certificate]: /gateway/{{page.kong_version}}/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object

--- a/app/gateway/2.6.x/configure/auth/oidc-google.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-google.md
@@ -2,7 +2,6 @@
 title: OpenID Connect with Google
 badge: enterprise
 ---
-## Introduction
 
 This guide covers an example OpenID Connect plugin configuration to authenticate browser clients using Google's identity provider.
 
@@ -59,9 +58,9 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/{{site.kong_version}}/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
-[add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
+[add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [oidc-id-token]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [oidc-standard-claims]: http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

--- a/app/gateway/2.6.x/configure/auth/oidc-mapping.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-mapping.md
@@ -2,7 +2,6 @@
 title: OIDC Authenticated Group Mapping
 badge: enterprise
 ---
-## Introduction
 
 Using Kong's OpenID Connect plugin (OIDC), you can map identity provider (IdP)
 groups to Kong roles. Adding a user to Kong in this way gives them access to
@@ -28,7 +27,7 @@ Manager.
 
 ## Prerequisites
 * An IdP with an authorization server and users with groups assigned
-* [{{site.ee_product_name}} installed and configured](/enterprise/{{page.kong_version}}/deployment/installation/overview)
+* [{{site.ee_product_name}} installed and configured](/gateway/{{page.kong_version}}/install-and-run)
 * Kong Manager enabled
 * RBAC enabled
 * (If using Kubernetes) [Helm](https://helm.sh/docs/intro/install/) installed
@@ -102,9 +101,9 @@ name:
     ```
 
     Where:
-    * [`rbac_role_id`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#list-roles):
+    * [`rbac_role_id`](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#list-roles):
     UUID of the role you want to assign.
-    * [`workspace_id`](/enterprise/{{page.kong_version}}/admin-api/workspaces/reference/#list-workspaces):
+    * [`workspace_id`](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#list-workspaces):
     UUID of the workspace to add the role to.
 
 3. Create an admin for the group:

--- a/app/gateway/2.6.x/configure/auth/oidc-okta.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-okta.md
@@ -2,13 +2,12 @@
 title: OpenID Connect with Okta
 badge: enterprise
 ---
-## Introduction
 
 This guide covers an example OpenID Connect plugin configuration to authenticate browser clients using an Okta identity provider.
 
 For information about configuring OIDC using Okta as an Identity provider
 in conjunction with the Application Registration plugin, see
-[Set Up External Portal Application Authentication with Okta and OIDC](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
+[Set Up External Portal Application Authentication with Okta and OIDC](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
 
 ## Prerequisites
 
@@ -135,6 +134,6 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
 [add-certificate]: /1.0.x/admin-api/#add-certificate
-[add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
+[add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
-[enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/
+[enable-plugin]: /gateway/{{page.kong_version}}/kong-manager/#plugin-object

--- a/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
@@ -11,7 +11,7 @@ This guide describes how to invite an **Admin** in Kong
 Manager. As an alternative, if a **Super Admin** wants to
 invite an **Admin** with the Admin API, it is possible to
 do so using
-[`/admins`](/enterprise/{{page.kong_version}}/admin-api/admins/reference/#invite-an-admin).
+[`/admins`](/gateway/{{page.kong_version}}/admin-api/admins/reference/#invite-an-admin).
 
 ## Invite an Admin
 

--- a/app/gateway/2.6.x/configure/auth/rbac/add-role.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-role.md
@@ -17,64 +17,45 @@ This guide describes how to create a custom **Role** in Kong
 Manager for a unique use case. As an alternative, if a
 **Super Admin** wants to create a **Role** with the Admin API,
 it is possible to do so using
-[`/rbac/roles`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role).
+[`/rbac/roles`](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role).
 To add **Permissions** to the new **Role**, use
-[`/rbac/roles/{name_or_id}/endpoints`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-endpoint-permission)
+[`/rbac/roles/{name_or_id}/endpoints`](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-endpoint-permission)
 for endpoints or
-[`/rbac/roles/{name_or_id}/entities`](/enterprise/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-entity-permission)
+[`/rbac/roles/{name_or_id}/entities`](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-entity-permission)
 for specific entities.
 
-### Prerequisites
+## Prerequisites
 
-* [`enforce_rbac = on`](/enterprise/{{page.kong_version}}/property-reference/#enforce_rbac)
-* Kong Enterprise has [started](/enterprise/{{page.kong_version}}/start-kong-securely)
+* [`enforce_rbac = on`](/gateway/{{page.kong_version}}/reference/property-reference/#enforce_rbac)
+* Kong Enterprise has [started](/gateway/{{page.kong_version}}/plan-and-deploy/security/start-kong-securely)
 * Logged in to Kong Manager as a **Super Admin**
 
-## Video Walkthrough
-
-<video width="100%" autoplay loop controls>
- <source src="https://konghq.com/wp-content/uploads/2019/02/role-creation-ent-34.mov" type="video/mp4">
- Your browser does not support the video tag.
-</video>
-
-## Step 1
-
-On the **Admins** page, to create a new **Role**, click the
+1. On the **Admins** page, to create a new **Role**, click the
 **Add Role** button at the top right of the list of **Roles**.
 
-## Step 2
-
-On the **Add Role** form, name the **Role** according to the
+1. On the **Add Role** form, name the **Role** according to the
 **Permissions** you want to grant.
 
-![New Role naming](https://konghq.com/wp-content/uploads/2018/11/km-new-role.png)
+    ![New Role naming](https://konghq.com/wp-content/uploads/2018/11/km-new-role.png)
 
-**Note:** It may be helpful for future reference to include
-a brief comment describing the reason for the **Permissions** or
-a summary of the **Role**.
+    **Note:** It may be helpful for future reference to include
+    a brief comment describing the reason for the **Permissions** or
+    a summary of the **Role**.
 
-## Step 3
+1. Click the **Add Permissions** button and fill out the form. Add the endpoint **Permissions** by marking the appropriate checkbox.
 
-Click the **Add Permissions** button and fill out the form. Add the endpoint **Permissions** by marking the appropriate checkbox.
+    ![New Role permissions](https://konghq.com/wp-content/uploads/2018/11/km-perms.png)
 
-![New Role permissions](https://konghq.com/wp-content/uploads/2018/11/km-perms.png)
+1. Click **Add Permission to Role** to see the permissions listed on the form.
 
-## Step 4
+    ![New Role permissions list](https://konghq.com/wp-content/uploads/2018/11/km-perms-list.png)
 
-Click **Add Permission to Role** to see the permissions listed on the form.
-
-![New Role permissions list](https://konghq.com/wp-content/uploads/2018/11/km-perms-list.png)
-
-## Step 5
-
-To forbid access to certain endpoints, click **Add Permission**
+1. To forbid access to certain endpoints, click **Add Permission**
 again and use the **negative** checkbox.
 
-![Negative permissions](https://konghq.com/wp-content/uploads/2018/11/km-negative-perms.png)
+    ![Negative permissions](https://konghq.com/wp-content/uploads/2018/11/km-negative-perms.png)
 
-## Step 6
-
-Submit the form and see the new **Role** appear on the
+1. Submit the form and see the new **Role** appear on the
 **Admins** page.
 
-![Roles list](https://konghq.com/wp-content/uploads/2018/11/km-roles-list.png)
+    ![Roles list](https://konghq.com/wp-content/uploads/2018/11/km-roles-list.png)

--- a/app/gateway/2.6.x/configure/auth/rbac/add-user.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-user.md
@@ -13,7 +13,7 @@ badge: free
 
 An RBAC User has the ability to access the Kong Enterprise Admin API. The Permissions assigned to their Role will define the types of actions they can perform with various Admin API objects.
 
-An [Admin](/enterprise/{{page.kong_version}}/kong-manager/security/#what-can-admins-do-in-kong-manager), like an RBAC User, has the ability to access the Kong Enterprise Admin API. The Admin also has the ability log in to Kong Manager. Like an RBAC User, an Admin’s Role will determine the types of actions it can perform—except that they will also have the ability to benefit from Kong Manager’s interface and visualizations.
+An [Admin](/gateway/{{page.kong_version}}/configure/auth/kong-manager/), like an RBAC User, has the ability to access the Kong Enterprise Admin API. The Admin also has the ability log in to Kong Manager. Like an RBAC User, an Admin’s Role will determine the types of actions it can perform—except that they will also have the ability to benefit from Kong Manager’s interface and visualizations.
 
 If creating a *service account* for Kong Enterprise, e.g., for a machine as part of an automated process, then an RBAC User is adequate.
 
@@ -21,10 +21,8 @@ If creating a *personal account* for Kong Enterprise, then Admin may be preferab
 
 #### Prerequisites
 
-* Authentication and RBAC are enabled, following the
-[Getting Started](/enterprise/{{page.kong_version}}/start-kong-securely/#prerequisites)
-guide
-* [Logged in as the Super Admin](/enterprise/{{page.kong_version}}/start-kong-securely/#step-4)
+* Authentication and RBAC are [enabled](/gateway/{{page.kong_version}}/plan-and-deploy/security/start-kong-securely)
+* [Logged in as the Super Admin](/gateway/{{page.kong_version}}/plan-and-deploy/security/start-kong-securely)
 or a user that has `/admins` and `/rbac` read and write access.
 
 ## How to Add an RBAC User in Kong Manager

--- a/app/gateway/2.6.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/index.md
@@ -5,52 +5,52 @@ badge: free
 
 ### Introduction to RBAC in Kong Manager
 
-In addition to authenticating **Admins** and segmenting **Workspaces**,
+In addition to authenticating Admins and segmenting Workspaces,
 Kong Enterprise has the ability to enforce Role-Based Access Control
-(RBAC) for all resources with the use of **Roles** assigned to **Admins**.
+(RBAC) for all resources with the use of Roles assigned to Admins.
 
-As the **Super Admin** (or any **Role** with **read** and **write**
+As the Super Admin (or any Role with read and write
 access to the `/admins` and `/rbac` endpoints), it is possible to
-create new **Roles** and customize **Permissions**.
+create new Roles and customize Permissions.
 
-In Kong Manager, RBAC affects how **Admins** are able to navigate
+In Kong Manager, RBAC affects how Admins are able to navigate
 through the application.
 
 ### Default Roles
 
-Kong includes Role-Based Access Control (RBAC). Every **Admin** using Kong Manager
-will need an assigned **Role** based on the resources they have **Permission** to access.
+Kong includes Role-Based Access Control (RBAC). Every Admin using Kong Manager
+will need an assigned Role based on the resources they have Permission to access.
 
-When a **Super Admin** starts Kong for the first time, the `default` **Workspace** will
-include three default **Roles**: `read-only`, `admin`, and `super-admin`. The three
-**Roles** have **Permissions** related to every **Workspace** in the cluster.
+When a Super Admin starts Kong for the first time, the `default` Workspace will
+include three default Roles: `read-only`, `admin`, and `super-admin`. The three
+Roles have Permissions related to every Workspace in the cluster.
 
-Similarly, if a **Role** is confined to certain **Workspaces**, the **Admin** assigned to it
-will not be able to see either the overview or links to other **Workspaces**.
+Similarly, if a Role is confined to certain Workspaces, the Admin assigned to it
+will not be able to see either the overview or links to other Workspaces.
 
-If a **Role** does not have **Permission** to access entire endpoints,
-the **Admin** assigned to the **Role** will not be able to see the related navigation links.
+If a Role does not have Permission to access entire endpoints,
+the Admin assigned to the Role will not be able to see the related navigation links.
 
 {:.important}
-> **Important:** Although a default **Admin** has full permissions with every
-endpoint in Kong, only a **Super Admin** has the ability to assign and modify RBAC **Permissions**. An **Admin** is not able to modify their own **Permissions** or delimit a **Super Admin's** **Permissions**.
+> Important: Although a default Admin has full permissions with every
+endpoint in Kong, only a Super Admin has the ability to assign and modify RBAC Permissions. An Admin is not able to modify their own Permissions or delimit a Super Admin's Permissions.
 
 ### RBAC in Workspaces
 
-RBAC **Roles** and **Permissions** will be specific to a **Workspace** if they are assigned
-from within one. For example, if there are two **Workspaces**, **Payments** and
-**Deliveries**, an **Admin** created in **Payments** will not have access to any
-endpoints in **Deliveries**.
+RBAC Roles and Permissions will be specific to a Workspace if they are assigned
+from within one. For example, if there are two Workspaces, Payments and
+Deliveries, an Admin created in Payments will not have access to any
+endpoints in Deliveries.
 
-When a **Super Admin** creates a new **Workspace**, there are three default **Roles** that
-mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
+When a Super Admin creates a new Workspace, there are three default Roles that
+mirror the cluster-level Roles, and a fourth unique to each Workspace:
 `workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
 `workspace-portal-admin`.
 
-These roles can be viewed in the **Teams** tab under **Roles**
+These roles can be viewed in the Teams tab under Roles
 
 ![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
 
-**IMPORTANT**: Any Role assigned in the **Default Workspace** will have
-**Permissions** applied to all subsequently created **Workspaces**. A **Super Admin**
-in `default` has RBAC **Permissions** across all **Workspaces**.
+IMPORTANT: Any Role assigned in the Default Workspace will have
+Permissions applied to all subsequently created Workspaces. A Super Admin
+in `default` has RBAC Permissions across all Workspaces.

--- a/app/gateway/2.6.x/configure/auth/service-directory-mapping.md
+++ b/app/gateway/2.6.x/configure/auth/service-directory-mapping.md
@@ -3,8 +3,6 @@ title: Mapping LDAP Service Directory Groups to Kong Roles
 badge: enterprise
 ---
 
-### Introduction
-
 Service Directory Mapping allows organizations to use their LDAP Directory for authentication and authorization in Kong Enterprise.
 
 After starting Kong Enterprise with the desired configuration, you can create new Admins whose usernames match those in your LDAP directory. Those users will then be able to accept invitations to join Kong Manager and log in with their LDAP credentials.
@@ -57,7 +55,7 @@ admin_gui_session_conf = { "secret":"set-your-string-here" }
 
 * Under all circumstances, the secret must be manually set to a string.
 *  If using HTTP instead of HTTPS, cookie_secure must be manually set to false.
-*  If using different domains for the Admin API and Kong Manager, cookie_samesite must be set to off. Learn more about these properties in [_Session Security in Kong Manager_](https://docs.konghq.com/enterprise/0.36-x/kong-manager/authentication/sessions/#session-security), and see [_example configurations_](https://docs.konghq.com/enterprise/0.36-x/kong-manager/authentication/sessions/#example-configurations).
+*  If using different domains for the Admin API and Kong Manager, cookie_samesite must be set to off. Learn more about these properties in [_Session Security in Kong Manager_](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions), and see [_example configurations_](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#example-configurations).
 
 ### Step 4: Configure LDAP Authentication for Kong Manager
 
@@ -105,7 +103,7 @@ admin_gui_auth_conf = {
 
 ### Define Roles with Permissions
 
-Define **Roles** with **Permissions** in Kong Enterprise, using the Admin API's [**_RBAC endpoints_**](https://docs.konghq.com/enterprise/latest/admin-api/rbac/reference/#update-or-create-a-role) or using Kong Manager's **Teams > [Admins tab](https://docs.konghq.com/enterprise/latest/kong-manager/administration/admins/invite/#using-the-organization-page-to-manage-users)**. You must manually define which Kong **Roles** correspond to each of the Service Directory's **Groups** using either of the following:
+Define **Roles** with **Permissions** in Kong Enterprise, using the Admin API's [**_RBAC endpoints_**](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#update-or-create-a-role) or using Kong Manager's **Teams > [Admins tab](/gateway/{{page.kong_version}}/configure/auth/rbac/add-user/)**. You must manually define which Kong **Roles** correspond to each of the Service Directory's **Groups** using either of the following:
 
 In Kong Manager's **Directory Mapping** section. Go to **Teams > Groups** tab.
 With the Admin API's **Directory Mapping** endpoints.
@@ -114,9 +112,9 @@ Kong Enterprise will not write to the Service Directory, for example, a Kong Ent
 
 ### User-Admin Mapping
 
-To map a Service Directory **User** to a Kong **Admin**, you must configure the **Admin's** username as the value of the **User's** name from their LDAP Distinguished Name (DN) corresponding the attribute configured in admin_gui_auth_conf. Creating an **Admin** account in [_Kong Manager_](https://docs.konghq.com/enterprise/latest/kong-manager/administration/admins/add-admin/) or using the [_Admin API_](https://docs.konghq.com/enterprise/latest/admin-api/admins/reference/#invite-an-admin).
+To map a Service Directory **User** to a Kong **Admin**, you must configure the **Admin's** username as the value of the **User's** name from their LDAP Distinguished Name (DN) corresponding the attribute configured in admin_gui_auth_conf. Creating an **Admin** account in [_Kong Manager_](/gateway/{{page.kong_version}}/configure/auth/rbac/add-admin) or using the [_Admin API_](/gateway/{{page.kong_version}}/admin-api/admins/reference/#invite-an-admin).
 
-For instructions on how to pair the bootstrapped **Super Admin** with a **Directory User**, see [_How to Set Up a Service Directory User as the First Super Admin_](/enterprise/{{page.kong_version}}/kong-manager/service-directory-mapping/#set-up-a-directory-user-as-the-first-super-admin).
+For instructions on how to pair the bootstrapped **Super Admin** with a **Directory User**, see [_How to Set Up a Service Directory User as the First Super Admin_](/gateway/{{page.kong_version}}/configure/auth/service-directory-mapping/#set-up-a-directory-user-as-the-first-super-admin).
 
 If you already have **Admins** with assigned **Roles** and want to use **Group** mapping instead, it is necessary to first remove all of their Roles. The Service Directory will serve as the system of record for **User** privileges. Assigned **Roles** will affect a user's privileges in addition to any roles mapped from **Groups.**
 

--- a/app/gateway/2.6.x/configure/logging.md
+++ b/app/gateway/2.6.x/configure/logging.md
@@ -4,7 +4,7 @@ title: Logging Reference
 
 ## Log Levels
 
-Log levels are set in [Kong's configuration](/enterprise/{{page.kong_version}}/property-reference/#log_level). Following are the log levels in increasing order of their severity: `debug`, `info`,
+Log levels are set in [Kong's configuration](/gateway/{{page.kong_version}}/reference/property-reference/#log_level). Following are the log levels in increasing order of their severity: `debug`, `info`,
 `notice`, `warn`, `error` and `crit`.
 
 - *`debug`:* It provides debug information about the plugin's runloop and each individual plugin or other components. Only to be used during debugging since it is too chatty.
@@ -21,7 +21,7 @@ With new regulations surrounding protecting private data like GDPR, there is a c
 
 For this example, let’s say you want to remove any instances of an email address from your Kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+To start using a custom NGINX template, first get a copy of our template. This can be found in the [Configuration Property reference](/gateway/{{page.kong_version}}/reference/property-reference/#custom-nginx-templates-embedding-kong) or copied from below
 
 ```
 # ---------------------

--- a/app/gateway/2.6.x/configure/network.md
+++ b/app/gateway/2.6.x/configure/network.md
@@ -2,8 +2,6 @@
 title: Network and Firewall
 ---
 
-## Introduction
-
 In this section you will find a summary about the recommended network and firewall settings for Kong.
 
 ## Ports
@@ -64,7 +62,7 @@ macOS/BSDs allow transparent proxying without `transparent` listen option. With 
 to start Kong as a `root` user or set the needed capabilities for the executable.
 
 
-[proxy_listen]: /enterprise/{{page.kong_version}}/property-reference/#proxy_listen
-[stream_listen]: /enterprise/{{page.kong_version}}/property-reference/#stream_listen
-[admin_listen]: /enterprise/{{page.kong_version}}/property-reference/#admin_listen
-[secure_admin_api]: /enterprise/{{page.kong_version}}/secure-admin-api
+[proxy_listen]: /gateway/{{page.kong_version}}/reference/property-reference/#proxy_listen
+[stream_listen]: /gateway/{{page.kong_version}}/reference/property-reference/#stream_listen
+[admin_listen]: /gateway/{{page.kong_version}}/reference/property-reference/#admin_listen
+[secure_admin_api]: /gateway/{{page.kong_version}}/admin-api/secure-admin-api

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/3rd-party-oauth.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/3rd-party-oauth.md
@@ -1,15 +1,14 @@
 ---
 title: Third-party OAuth2 Support for Application Registration
+badge: enterprise
 ---
-
-## Introduction
 
 Third-party OAuth2 support allows developers to centralize application
 credentials management with the [supported Identity Provider](#idps) of their
 choice. To use the external IdP feature, set the `portal_app_auth`
 configuration option to `external-oauth2` in the
 `kong.conf.default` configuration file. For more information, see setting the
-[Authorization Provider Strategy](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy).
+[Authorization Provider Strategy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy).
 
 The Kong [OIDC](/hub/kong-inc/openid-connect/) and
 [Portal Application Registration](/hub/kong-inc/application-registration/)
@@ -17,7 +16,7 @@ plugins are used in conjunction with each other on a Service:
 
 * The OIDC plugin handles all aspects of the OAuth2 handshake, including
 looking up the Consumer via
-[custom claim](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config#auth-server-cclaim)
+[custom claim](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config#auth-server-cclaim)
 (the `custom_id` matches the identity provider `client_id` claim).
 
 * The Application Registration plugin is responsible for checking the mapped
@@ -31,9 +30,9 @@ following providers have been tested for the current version of the Kong
 Portal Application Registration plugin used in tandem with the Kong OIDC plugin:
 
 * [Okta](https://developer.okta.com/). See the
-  [Okta setup example](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
+  [Okta setup example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
 * [Azure](https://azure.microsoft.com/). See the
-  [Azure setup example](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
+  [Azure setup example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
 * [Ping Identity](https://www.pingidentity.com/).
 
 ### Resources
@@ -102,7 +101,7 @@ Due to limitations of the OIDC plugin, a single plugin instance cannot handle
 dynamic `client_id's` provisioned from multiple sources (applications).
 To circumvent this issue, the IdP Issuer URL is exposed to developers on the
 Dev Portal application show page when
-[`show_issuer`](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#app-reg-params) is enabled in the
+[`show_issuer`](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#app-reg-params) is enabled in the
 Application Registration plugin. Developers can hit the Issuer URL directly to
 provision an access token. After getting the access token, requests can be made
 against the proxy.

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/auth-provider-strategy.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/auth-provider-strategy.md
@@ -1,8 +1,7 @@
 ---
 title: Authorization Provider Strategy for Application Registration
+badge: enterprise
 ---
-
-## Overview
 
 In the 1.5.x beta version of the Application
 Registration plugin, the feature was tightly coupled with OAuth2. Kong was the
@@ -15,13 +14,13 @@ providers. Developers have the flexibility to choose from either
 Kong or a third-party identity provider (IdP) as the system of record for
 application credentials. With third-party (external) OAuth2 support, developers
 can centralize application credential management with the
-[supported identity provider](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#idps)
+[supported identity provider](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#idps)
 of their choice.
 
 In the {{site.ee_product_name}} 2.2.1.x version and later, support has been added
 for the Key Authentication plugin to use with Kong as the system of record.
 
-### Supported Authentication Plugins
+## Supported Authentication Plugins
 
 OAuth2 plugins for use with the Application Registration plugin:
 
@@ -42,7 +41,7 @@ OAuth2 plugins for use with the Application Registration plugin:
 The third-party authorization strategy (`external-oauth2`) applies to all
 applications across all Workspaces (Dev Portals) in a {{site.base_gateway}} cluster.
 
-### Authorization provider strategy configuration for Application Registration {#portal-app-auth}
+## Authorization provider strategy configuration for Application Registration {#portal-app-auth}
 
 The `portal_app_auth` configuration option must be set in `kong.conf` to enable
 the Dev Portal Application Registration plugin with your chosen
@@ -61,10 +60,10 @@ Available options:
   Portal Application Registration plugin is used in conjunction with the
   OIDC plugin. The `external-oauth2` option can be used with any deployment type.
   The `external-oauth2` option must be used with
-  [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/)
+  [hybrid mode](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode/)
   deployments because hybrid mode does not support `kong-oauth2`.
 
-#### Set external portal authentication {#set-external-oauth2}
+### Set external portal authentication {#set-external-oauth2}
 
 If you are using an external IdP, follow these steps.
 
@@ -80,12 +79,12 @@ If you are using an external IdP, follow these steps.
             # Currently accepts kong-oauth2 or external-oauth2.
    ```
 
-2. [Restart](/enterprise/{{page.kong_version}}/cli/#kong-restart) your Kong Enterprise
+2. [Restart](/gateway/{{page.kong_version}}/reference/cli/#kong-restart) your Kong Enterprise
    instance.
 
-### Next Steps
+## Next Steps
 
-1. Enable the [Application Registration plugin](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
+1. Enable the [Application Registration plugin](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
 
 2. Enable a supported authentication plugin on the same Service as the Application Registration plugin,
    as appropriate for your authorization strategy.
@@ -99,14 +98,14 @@ If you are using an external IdP, follow these steps.
     * If using the `kong-oauth2` authorization strategy with key authentication, configure the
     [Key Auth](/hub/kong-inc/key-auth/) plugin on the same Service as the Application
     Registration plugin. You can use either the
-    [Kong Manager GUI](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-key-auth-plugin)
+    [Kong Manager GUI](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-key-auth-plugin)
     or cURL commands as documented on the Plugin Hub. The Key Auth plugin
     cannot be used in hybrid mode.
 
     Strategy `external-oauth2`:
 
     1. If you plan to use external OAuth2, review the
-    [recommended workflows](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#supported-oauth-flows).
+    [recommended workflows](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#supported-oauth-flows).
 
     2. If using the third-party authorization strategy
     (`external-oauth2`), configure the OIDC plugin on the same Service as the
@@ -117,5 +116,5 @@ If you are using an external IdP, follow these steps.
 
     3. Configure the identity provider for your application, configure your
     application in {{site.base_gateway}}, and associate them with each other. See the
-    [Okta](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config)
-    or the [Azure](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config) setup examples.
+    [Okta](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config)
+    or the [Azure](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config) setup examples.

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/azure-oidc-config.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/azure-oidc-config.md
@@ -1,17 +1,16 @@
 ---
 title: Set Up External Portal Application Authentication with Azure AD and OIDC
+badge: enterprise
 ---
-
-## Overview
 
 These instructions help you set up Azure AD as your third-party identity provider
 for use with the Kong OIDC and Portal Application Registration plugins.
 
-### Prerequisites
+## Prerequisites
 
 - The `portal_app_auth` configuration option is configured for your OAuth provider
   and strategy (`kong-oauth2` or `external-oauth2`). See
-  [Configure the Authorization Provider Strategy](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy) for the Portal Application Registration plugin.
+  [Configure the Authorization Provider Strategy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy) for the Portal Application Registration plugin.
 
 ## Create an Application in Azure
 
@@ -210,7 +209,7 @@ next procedure.
    ![Azure Example Application](/assets/images/docs/dev-portal/azure-app-details.png)
 
    Because you enabled
-   [Auto-approve](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration##aa)
+   [Auto-approve](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration##aa)
    on the associated Application Registration Plugin, an admin won't need to
    approve the request.
 

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -1,8 +1,8 @@
 ---
 title: Enable Application Registration
+badge: enterprise
 ---
 
-## Introduction
 Application Registration allows registered developers on the Kong Dev Portal to
 authenticate with supported Authentication plugins against a Service on Kong. Either {{site.base_gateway}} or
 external identity provider admins can selectively admit access to Services using Kong Manager.
@@ -17,13 +17,13 @@ key authentication, version 2.2.1.0 or later.
   developers.
 * The `portal_app_auth` configuration option is configured for your OAuth provider
   and strategy (`kong-oauth2` default or `external-oauth2`). See
-[Configure the Authorization Provider Strategy](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy) for the Portal Application Registration plugin.
+[Configure the Authorization Provider Strategy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy) for the Portal Application Registration plugin.
 * Authorization provider configured if using a supported third-party
   identity provider with the OIDC plugin:
   * For example instructions using Okta as an identity provider, refer to the
-    [Okta example](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
+    [Okta example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
   * For example instructions using Azure AD as an identity provider, refer to the
-    [Azure example](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
+    [Azure example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
 
 ## Enable Application Registration on a Service using Kong Manager {#enable-app-reg-plugin}
 
@@ -48,7 +48,7 @@ In Kong Manager, access the Service for which you want to enable Application Reg
 
    **Important:** Exposing
    the Issuer URL is essential for the
-   [Authorization Code Flow](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow)
+   [Authorization Code Flow](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow)
    workflow configured for third-party identity providers.
 
    ![Issuer URL](/assets/images/docs/dev-portal/dev-portal-issuer-url.png)
@@ -64,7 +64,7 @@ In Kong Manager, access the Service for which you want to enable Application Reg
 | `Auto Approve` | If enabled, all new Service contract requests are automatically approved. Otherwise, Dev Portal admins must manually approve requests. Default: `false`. |
 | `Description` | Description displayed in the information about a Service in the Dev Portal. Optional. |
 | `Display Name` | Unique name displayed in the information about a Service in the Dev Portal. Required. |
-| `Show Issuer` | Displays the Issuer URL in the Service Details page. Default: `false`. **Important:** Exposing the **Issuer URL** is essential for the [Authorization Code Flow](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow) workflow configured for third-party identity providers. |
+| `Show Issuer` | Displays the Issuer URL in the Service Details page. Default: `false`. **Important:** Exposing the **Issuer URL** is essential for the [Authorization Code Flow](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow) workflow configured for third-party identity providers. |
 
 ## Next steps
 
@@ -79,7 +79,7 @@ The OAuth2 plugin cannot be used in hybrid mode.
 (`kong-oauth2`) with key authentication, configure the Kong
 [Key Auth](/hub/kong-inc/key-auth/) plugin as appropriate for your authorization
 requirements. You can use either the
-[Kong Manager GUI](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-key-auth-plugin)
+[Kong Manager GUI](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-key-auth-plugin)
 or cURL commands as documented on the Plugin Hub. The Key Auth plugin
 cannot be used in hybrid mode.
 

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/enable-key-auth-plugin.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/enable-key-auth-plugin.md
@@ -1,8 +1,7 @@
 ---
 title: Enable Key Authentication for Application Registration
+badge: enterprise
 ---
-
-## Overview
 
 You can use the Key Authentication plugin for authentication in conjunction with
 the Application Registration plugin.
@@ -14,7 +13,7 @@ You can use the same Client ID credential for a Service that has the OAuth2 plug
 
 * {{site.ee_product_name}} is installed, version 2.2.1.0 or later.
 * Create a Service.
-* Enable the [Application Registration plugin](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
+* Enable the [Application Registration plugin](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
 * Activate your application for a Service if you have not already done so. The
 Service Contract must be approved by an Admin if auto approve is not enabled.
 * [Generate a credential](#gen-client-id-cred) if you don't want to use the default credential initially created for you.

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/managing-applications.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/managing-applications.md
@@ -1,11 +1,11 @@
 ---
 title: Manage Applications
+badge: enterprise
 ---
 
-## Manage Developer Applications from Kong Manager
 Developers can create applications from the Kong Dev Portal. An application can apply to any number of Services. This is called a Service Contract. To use an application with a Service, the Service Contract must have an Approved status. To enable automatic approval for all new Service Contracts, enable Auto-approve for the Portal Application Registration plugin.
 
-### Create an Application
+## Create an Application
 
 1. Log in to the Kong Dev Portal.
 2. Click **My Apps** in the top navigation bar.
@@ -20,11 +20,11 @@ generate more credentials, and view your application status against a list of
 Services.
 6. Before you can use your application, you must activate it to create a Service
 Contract for the Service. In the Services section of the Application Dashboard,
-click **Activate** on the Service you want to use. If [Auto-approve](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration##aa) is not
+click **Activate** on the Service you want to use. If [Auto-approve](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration##aa) is not
 enabled, your application will remain pending until an admin approves your
 request.
 
-### View all Service Contracts for an Application
+## View all Service Contracts for an Application
 
 A list of all applications in a Workspace can be accessed from the left navigation pane.
 
@@ -33,7 +33,7 @@ A list of all applications in a Workspace can be accessed from the left navigati
 3. In the Service Contracts section, click the **Requested Access** tab to view Service Contracts requests for the application. Approve, revoke, or reject
 requests.
 
-### View all Application Contracts for a Service
+## View all Application Contracts for a Service
 
 View all Application Contracts and their status for a Service from the
 **Service** page.
@@ -42,7 +42,7 @@ View all Application Contracts and their status for a Service from the
 2. Select the Service for which you have Application Registration enabled.
 3. From the Service Contracts tab, view all Approved, Revoked, Rejected, and Requested Access for the Service.
 
-### Add a Document to your Service
+## Add a Document to your Service
 When using Application Registration, it is recommended to link documentation
 (OAS/Swagger spec) to your Service. Doing so allows Dev Portal users to easily
 register Application Contracts for their applications from the documentation

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/okta-config.md
@@ -1,8 +1,7 @@
 ---
 title: Set Up External Portal Application Authentication with Okta and OIDC
+badge: enterprise
 ---
-
-## Overview
 
 These instructions help you set up Okta as your third-party identity provider
 for use with the Kong OIDC and Portal Application Registration plugins.
@@ -69,7 +68,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
    ```
 
 8. Configure a Portal Application Registration plugin on the Service as well. See
-[Application Registration](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#config-app-reg-plugin).
+[Application Registration](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#config-app-reg-plugin).
 
 ## Register an application in Okta
 
@@ -85,7 +84,7 @@ your Okta application will vary:
 
      ![Okta Create New Application](/assets/images/docs/dev-portal/okta-client-creds-app.png)
 
-    You will need your `client_id` and `client_secret` later on when you [authenticate with the proxy](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#cc-flow).
+    You will need your `client_id` and `client_secret` later on when you [authenticate with the proxy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#cc-flow).
 
     ![Okta Client Credentials](/assets/images/docs/dev-portal/okta-client-id-secret.png)
 
@@ -118,4 +117,4 @@ This example assumes Client Credentials is the chosen OAuth flow.
 
 Now that the application has been created, developers can authenticate with the
 endpoint using the supported and recommended
-[third-party OAuth flows](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth).
+[third-party OAuth flows](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth).

--- a/app/gateway/2.6.x/developer-portal/administration/developer-permissions.md
+++ b/app/gateway/2.6.x/developer-portal/administration/developer-permissions.md
@@ -1,8 +1,7 @@
 ---
 title: Developer Roles and Content Permissions
+badge: enterprise
 ---
-
-## Introduction
 
 Access to the Dev Portal can be fine-tuned with the use of Developer
 Roles and Content Permissions, managed through the Dev Portal Permissions page
@@ -47,7 +46,7 @@ assigned the `*` role by default. All other content files have no roles by
 default. This means that until a role is added, the file is unauthenticated
 even if Dev Portal Authentication is enabled. Content Permissions are ignored
 when Dev Portal Authentication is disabled. For more information, visit the
-<a href="/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication">Dev Portal Authentication</a> section.
+<a href="/gateway/{{page.kong_version}}/developer-portal/configuration/authentication">Dev Portal Authentication</a> section.
 
 ## readable_by attribute
 

--- a/app/gateway/2.6.x/developer-portal/administration/managing-developers.md
+++ b/app/gateway/2.6.x/developer-portal/administration/managing-developers.md
@@ -1,8 +1,9 @@
 ---
 title: Managing Developers
+badge: enterprise
 ---
 
-### Developer Status
+## Developer Status
 
 A status represents the state of a developer and the access they have to the Dev
  Portal and APIs:
@@ -21,7 +22,7 @@ A status represents the state of a developer and the access they have to the Dev
 
 ![Managing Developers](https://konghq.com/wp-content/uploads/2018/05/gui-developer-tabs.png)
 
-### Approving Developers
+## Approving Developers
 
 Developers who have requested access to a Dev Portal will appear under the
 **Requested Access** tab. From this tab, you can choose to *Accept* or *Reject*
@@ -29,24 +30,24 @@ the developer from the actions in the table row. After selecting an action, the
 corresponding tab is updated.
 
 
-### Viewing Approved Developers
+## View Approved Developers
 
 To view all currently approved developers, click the **Approved** tab. From here, you can choose to *Revoke* or *Delete* a particular developer. Additionally, you can use this view to send an email to a developer with the **Email Developer** `mailto` link. See [Emailing Developers](#emailing-developers) for more info.
 
 
-### Viewing Revoked Developers
+## View Revoked Developers
 
 To view all currently revoked developers, click the **Revoked** tab. From here, you can choose to *Re-approve* or *Delete* a developer.
 
 
-### Viewing Rejected Developers
+### View Rejected Developers
 
 To view all currently rejected developers, click the **Rejected** tab. Rejected developers completed the registration flow on your Dev Portal but were rejected from the **Request Access** tab. You may *Approve* or *Delete* a developer from this tab.
 
 
-### Emailing Developers
+## Email Developers
 
-#### Inviting Developers to Register
+### Invite Developers to Register
 
 To invite a single or multiple developers:
 
@@ -61,10 +62,10 @@ Each developer is bcc'd by default for privacy. You may choose to edit the messa
 ![Invite Developers](https://konghq.com/wp-content/uploads/2018/05/invite-developers.png)
 
 
-### Developer Management Property Reference
+## Developer Management Property Reference
 
 
-#### portal_auto_approve
+### portal_auto_approve
 
 **Default:** `off`
 
@@ -79,7 +80,7 @@ When set to `off`, a Kong admin will have to manually approve the Developer
 using Kong Manager or the API.
 
 
-#### portal_invite_email
+### portal_invite_email
 
 **Default:** `on`
 
@@ -88,7 +89,7 @@ When enabled, Kong admins can invite developers to a Dev Portal by using
 the Invite button in Kong Manager.
 
 
-#### portal_access_request_email
+### portal_access_request_email
 
 **Default:** `on`
 
@@ -100,7 +101,7 @@ When disabled, Kong admins will have to manually check the Kong Manager to view
 any requests.
 
 
-#### portal_approved_email
+### portal_approved_email
 
 **Default:** `on`
 
@@ -113,7 +114,7 @@ approved. It is suggested to only disable this feature if `portal_auto_approve`
 is enabled.
 
 
-#### portal_reset_email
+### portal_reset_email
 
 **Default:** `on`
 
@@ -125,7 +126,7 @@ When disabled, developers will *not* be able to reset their account passwords.
 Kong Admins will have to manually create new credentials for the Developer in
 the Kong Manager.
 
-#### portal_token_exp
+### portal_token_exp
 
 **Default:** `21600`
 
@@ -134,7 +135,7 @@ Duration in seconds for the expiration of the Dev Portal reset password token.
 Default is `21600` (six hours).
 
 
-#### portal_reset_success_email
+### portal_reset_success_email
 
 **Default:** `on`
 

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/adding-registration-fields.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/adding-registration-fields.md
@@ -1,9 +1,7 @@
 ---
 title: Adding Dev Portal Registration Fields
+badge: enterprise
 ---
-
-
-### Introduction
 
 When authentication is enabled for a Dev Portal, the only required
 fields by default are **full name**, **email**, and **password**. However, you

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/basic-auth.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/basic-auth.md
@@ -1,8 +1,7 @@
 ---
 title: Enable Basic Auth in the Dev Portal
+badge: enterprise
 ---
-
-## Introduction
 
 The Kong Dev Portal can be fully or partially authenticated using HTTP protocol's Basic Authentication scheme. Requests are sent with an Authorization header that
 contains the word `Basic` followed by the base64-encoded `username:password` string.
@@ -18,13 +17,13 @@ Basic Authentication for the Dev Portal can be enabled using any of the followin
 - Enabling authentication in the Dev Portal requires use of the
 Sessions plugin. Developers will not be able to log in if this is not properly set.
 For more information, see
-[Sessions in the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication/sessions).
+[Sessions in the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/authentication/sessions).
 
 - When Dev Portal Authentication is enabled, content files remain unauthenticated until a role is applied to them. The exceptions are `settings.txt` and `dashboard.txt`, which begin with the `*` role. For more information, see
-[Developer Roles and Content Permissions](/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions).
+[Developer Roles and Content Permissions](/gateway/{{page.kong_version}}/developer-portal/administration/developer-permissions).
 
 
-### Enable Portal Session Config
+## Enable Portal Session Config
 
 In the Kong configuration file, set the `portal_session_conf` property:
 
@@ -45,15 +44,15 @@ and `cookie_samesite` properties as follows:
 portal_session_conf={ "cookie_name":"portal_session","secret":"<CHANGE_THIS>","storage":"kong","cookie_secure":false,"cookie_domain":"<.your_subdomain.com>","cookie_samesite":"off"  }
 ```
 
-#### See Also
+### See Also
 
 - For more information about portal session configuration, see
-[Sessions](/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication/sessions#portal-session-conf).
+[Sessions](/gateway/{{page.kong_version}}/developer-portal/configuration/authentication/sessions#portal-session-conf).
 
 - For more information about domains and cookies in Dev Portal sessions, see
-[Domains](/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication/sessions#domains).
+[Domains](/gateway/{{page.kong_version}}/developer-portal/configuration/authentication/sessions#domains).
 
-### Enable Basic Auth Using Kong Manager
+## Enable Basic Auth Using Kong Manager
 
 1. Navigate to the Dev Portal's **Settings** page.
 2. Find **Authentication plugin** under the **Authentication** tab.
@@ -62,7 +61,7 @@ portal_session_conf={ "cookie_name":"portal_session","secret":"<CHANGE_THIS>","s
 
 ![Authentication plugin](/assets/images/docs/dev-portal/portal-settings-auth-plugin.png)
 
-### Enable Basic Auth Using the Command Line
+## Enable Basic Auth Using the Command Line
 
 To patch a Dev Portal's authentication property directly, run:
 
@@ -71,7 +70,7 @@ $ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE_NAME> \
   --data "config.portal_auth=basic-auth"
 ```
 
-### Enable Basic Auth Using `kong.conf`
+## Enable Basic Auth Using `kong.conf`
 
 Kong allows for a default authentication plugin to be set in the Kong
 configuration file with the `portal_auth` property.

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/key-auth.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/key-auth.md
@@ -1,8 +1,7 @@
 ---
 title: Enable Key Auth in the Dev Portal
+badge: enterprise
 ---
-
-### Introduction
 
 The Kong Dev Portal can be fully or partially authenticated using API keys or **Key
 Authentication**. Users provide a unique key upon registering and use this key
@@ -16,9 +15,9 @@ Key Authentication for the Dev Portal can be enabled in three ways:
 
 >**Warning** Enabling authentication in the Dev Portal requires use of the
 > Sessions plugin. Developers will not be able to login if this is not set
-> properly. More information about [Sessions in the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication/sessions)
+> properly. More information about [Sessions in the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/authentication/sessions)
 
-### Enable Portal Session Config
+## Enable Portal Session Config
 
 ```
 portal_session_conf={ "cookie_name": "portal_session", "secret": "CHANGE_THIS", "storage": "kong" }
@@ -30,16 +29,16 @@ If using HTTP while testing, include `"cookie_secure": false` in the config:
 portal_session_conf={ "cookie_name": "portal_session", "secret": "CHANGE_THIS", "storage": "kong", "cookie_secure": false }
 ```
 
-### Enable Key Auth via Kong Manager
+## Enable Key Auth via Kong Manager
 
 1. Navigate to the Dev Portal's **Settings** page.
 2. Find **Authentication plugin** under the **Authentication** tab.
 3. Select **Key Authentication** from the drop down.
 4. Click **Save Changes**.
 
->**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
+>**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/gateway/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
-### Enable Key Auth via the Command Line
+## Enable Key Auth via the Command Line
 
 To patch a Dev Portal's authentication property directly, run:
 
@@ -48,9 +47,9 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
   --data "config.portal_auth=key-auth"
 ```
 
->**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
+>**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/gateway/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
-### Enable Key Auth via the Kong.conf
+## Enable Key Auth via the Kong.conf
 
 Kong allows for a `default authentication plugin` to be set in the Kong
 configuration file with the `portal_auth` property.

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/oidc.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/oidc.md
@@ -1,13 +1,12 @@
 ---
 title: Enable OpenID Connect in the Dev Portal
+badge: enterprise
 ---
-
-### Introduction
 
 The [OpenID Connect Plugin](/hub/kong-inc/openid-connect/) (OIDC)
 allows the Kong Dev Portal to hook into existing authentication setups using third-party
 *Identity Providers* (IdP) such as Google, Okta, Microsoft Azure AD,
-[Curity](/enterprise/latest/plugins/oidc-curity/#kong-dev-portal-authentication), etc.
+[Curity](/gateway/{{page.kong_version}}/configure/auth/oidc-curity/#kong-dev-portal-authentication), etc.
 
 [OIDC](/hub/kong-inc/openid-connect/) must be used with
 the `session` method, utilizing cookies for Dev Portal File API requests.
@@ -27,11 +26,11 @@ OIDC for the Dev Portal can be enabled in one of the following ways:
 - [The Kong configuration file](#enable-oidc-using-kongconf)
 
 
-### Portal Session Plugin Config
+## Portal Session Plugin Config
 
 Session Plugin Config does not apply when using OpenID Connect.
 
-### Sample Configuration Object
+## Sample Configuration Object
 
 Below is a sample configuration JSON object for using *Google* as the Identity
 Provider:
@@ -97,7 +96,7 @@ Example:
 
 ```
 
-### Enable OIDC using Kong Manager
+## Enable OIDC using Kong Manager
 
 1. Navigate to the Dev Portal's **Settings** page.
 2. Find **Authentication plugin** under the **Authentication** tab.
@@ -107,9 +106,9 @@ Example:
 into the provided text area.
 4. Click **Save Changes**.
 
->**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
+>**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/gateway/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
-### Enable OIDC using the Command Line
+## Enable OIDC using the Command Line
 
 You can use the Kong Admin API to set up Dev Portal Authentication.
 To patch a Dev Portal's authentication property directly, run:
@@ -120,9 +119,9 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
   "config.portal_auth_conf=<REPLACE WITH JSON CONFIG OBJECT>
 ```
 
->**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
+>**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/gateway/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
-### Enable OIDC using kong.conf
+## Enable OIDC using kong.conf
 
 Kong allows for a `default authentication plugin` to be set in the Kong
 configuration file with the `portal_auth` property.

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/sessions.md
@@ -2,13 +2,14 @@
 title: Sessions in the Dev Portal
 ---
 
-⚠️**Important:** Portal Session Configuration does not apply when using [OpenID Connect](/hub/kong-inc/openid-connect) for Dev Portal authentication. The following information assumes that the Dev Portal is configured with `portal_auth` other than `openid-connect`; for example, `key-auth` or `basic-auth`.
+{:.important}
+> **Important**: Portal Session Configuration does not apply when using [OpenID Connect](/hub/kong-inc/openid-connect) for Dev Portal authentication. The following information assumes that the Dev Portal is configured with `portal_auth` other than `openid-connect`; for example, `key-auth` or `basic-auth`.
 
 ## How does the Sessions Plugin work in the Dev Portal?
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/gateway/{{page.kong_version}}/reference/property-reference/#portal_api_url) and [portal_gui_host](/gateway/{{page.kong_version}}/reference/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal
 
@@ -58,7 +59,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
+* If using different subdomains for the [portal_api_url](/gateway/{{page.kong_version}}/reference/property-reference/#portal_api_url) and [portal_gui_host](/gateway/{{page.kong_version}}/property-reference/#portal_gui_host), see the example below for [Domains](/gateway/{{page.kong_version}}/developer-portal/configuration/authentication/sessions/#domains).
 
 {:.important}
 > **Important:** Sessions are not invalidated when a user logs out if `"storage": "cookie"`

--- a/app/gateway/2.6.x/developer-portal/configuration/smtp.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/smtp.md
@@ -1,8 +1,7 @@
 ---
 title: Dev Portal SMTP Configuration
+badge: enterprise
 ---
-
-### Introduction
 
 The following property reference outlines each email and email variable used by the Dev Portal to send emails to Kong admins and developers.
 
@@ -15,10 +14,10 @@ curl http://localhost:8001/workspaces/<WORKSPACE_NAME> \
 
 If they are not modified manually, the Dev Portal will use the default value defined in the Kong Configuration file.
 
-In 1.3.0.1 or greater, [Dev Portal email content and styling can be customized via template files](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/emails/)
+In 1.3.0.1 or greater, [Dev Portal email content and styling can be customized via template files](/gateway/{{page.kong_version}}/developer-portal/theme-customization/emails/)
 
 
-### portal_invite_email
+## portal_invite_email
 
 **Default:** `on`
 
@@ -36,7 +35,7 @@ Please visit `<DEV_PORTAL_URL/register>` to create your account.
 ```
 
 
-### portal_email_verification
+## portal_email_verification
 
 **Default:** `off`
 
@@ -44,7 +43,7 @@ Please visit `<DEV_PORTAL_URL/register>` to create your account.
 When enabled, developers will receive an email upon registration to verify their account. Developers will not be able to use the Dev Portal until their account is verified, even if auto-approve is enabled.
 
 
-### portal_access_request_email
+## portal_access_request_email
 
 **Default:** `on`
 
@@ -61,7 +60,7 @@ Please visit <KONG_MANAGER_URL/developers/requested> to review this request.
 ```
 
 
-### portal_approved_email
+## portal_approved_email
 
 **Default:** `on`
 
@@ -77,7 +76,7 @@ Please visit <DEV PORTAL URL/login> to login.
 
 ```
 
-### portal_reset_email
+## portal_reset_email
 
 **Default:** `on`
 
@@ -101,7 +100,7 @@ If you didn't make this request, keep your account secure by clicking
 the link above to change your password.
 ```
 
-### portal_reset_success_email
+## portal_reset_success_email
 
 **Default:** `on`
 
@@ -122,7 +121,7 @@ Click the link below to sign in with your new credentials.
 ```
 
 
-### portal_emails_from
+## portal_emails_from
 
 **Default:** `nil`
 
@@ -136,7 +135,7 @@ portal_emails_from = Your Name <example@example.com>
 ```
 
 
-### portal_emails_reply_to
+## portal_emails_reply_to
 
 **Default:** `nil`
 

--- a/app/gateway/2.6.x/developer-portal/configuration/workspaces.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/workspaces.md
@@ -1,15 +1,14 @@
 ---
 title: Running Multiple Dev Portals with Workspaces
+badge: enterprise
 ---
 
-### Introduction
-
 Kong supports running multiple instances of the Dev Portal with the use of
-[**Workspaces**](/enterprise/{{page.kong_version}}/admin-api/workspaces/reference). This allows each Workspace to enable
+[**Workspaces**](/gateway/{{page.kong_version}}/admin-api/workspaces/reference). This allows each Workspace to enable
 and maintain separate Dev Portals (complete with separate files, settings, and
 authorization) from within a single instance of Kong.
 
-### Managing Multiple Dev Portals within Kong Manager
+## Managing Multiple Dev Portals within Kong Manager
 
 A snapshot of every Dev Portal within an instance of Kong can be viewed via
 the Kong Manager's **Dev Portals** top navigation tab.
@@ -25,7 +24,7 @@ in the upper right corner of each card)
 
 ![Dev Portals Overview Page](/assets/images/docs/dev-portal/dev-portals-overview.png)
 
-### Enabling a Workspace's Dev Portal
+## Enabling a Workspace's Dev Portal
 
 When a Workspace other than **default** is created, that Workspace's Dev Portal
 will remain `disabled` until it is manually enabled.
@@ -40,12 +39,12 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE_NAME> \
  --data "config.portal=true"
 ```
 
-On initialization, Kong will populate the new Dev Portal with the [**Default Settings**](/enterprise/{{page.kong_version}}/property-reference/#dev-portal) defined in Kong's configuration file.
+On initialization, Kong will populate the new Dev Portal with the [**Default Settings**](/gateway/{{page.kong_version}}/reference/property-reference/#dev-portal) defined in Kong's configuration file.
 
 >*Note* A Workspace can only enable a Dev Portal if the Dev Portal feature has been enabled in Kong's configuration.
 
 
-### Defining the Dev Portal's URL structure
+## Defining the Dev Portal's URL structure
 
 The URL of each Dev Portal is automatically configured upon initialization and
 is determined by four properties:
@@ -62,17 +61,17 @@ Example URL with subdomains enabled: `http://example-workspace.localhost:8003`
 The first three properties are controlled by Kong's configuration file and
 cannot be edited via the Kong Manager.
 
-### Overriding Default Settings
+## Overriding Default Settings
 
-On initialization, the Dev Portal will be configured using the [**Default Portal Settings**](/enterprise/{{page.kong_version}}/property-reference/#dev-portal) defined in Kong's configuration file.
+On initialization, the Dev Portal will be configured using the [**Default Portal Settings**](/gateway/{{page.kong_version}}/reference/property-reference/#dev-portal) defined in Kong's configuration file.
 
 These settings can be manually overridden in the Dev Portals **Settings** tab
 in the Kong Manager or by patching the setting directly.
 
-### Workspace Files
+## Workspace Files
 
 On initialization of a Workspace's Dev Portal, a copy of the **default** Dev Portal files will be made and inserted into the new Dev Portal. This allows for the easy transference of a customized Dev Portal theme and allows **default** to act as a 'master template' -- however, the Dev Portal will not continue to sync changes from the **default** Dev Portal after it is first enabled.
 
-### Developer Access
+## Developer Access
 
 Access is not synced between Dev Portals. If an Admin or Developer would like access to multiple Dev Portals, they must sign up for each Dev Portal individually.

--- a/app/gateway/2.6.x/developer-portal/enable-dev-portal.md
+++ b/app/gateway/2.6.x/developer-portal/enable-dev-portal.md
@@ -1,5 +1,6 @@
 ---
 title: How To Enable the Dev Portal
+badge: enterprise
 ---
 
 Enable Dev Portal in the Kong Configuration or within a Docker container for Docker installations.
@@ -36,9 +37,9 @@ configuration file (`kong.conf`):
 ## Enable Dev Portal with Docker installation
 
 {:.note}
-> This feature is only available with a [{{site.konnect_product_name}} Enterprise](/enterprise/{{page.kong_version}}/deployment/licensing) subscription.
+> This feature is only available with a [{{site.konnect_product_name}} Enterprise](/gateway/{{page.kong_version}}/plan-and-deploy/licenses) subscription.
 
-1. [Deploy a license](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+1. [Deploy a license](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license).
 
 2. In your Docker container, set the Portal URL and set `KONG_PORTAL` to `on`:
 

--- a/app/gateway/2.6.x/developer-portal/files-api.md
+++ b/app/gateway/2.6.x/developer-portal/files-api.md
@@ -1,13 +1,12 @@
 ---
 title: Using the Portal Files API
+badge: enterprise
 ---
-
-## Portal Files API Overview
 
 The Portal Files API can be used as an alternative to the Portal CLI to manage
 dev portal content. Portal content must maintain a specific structure to render
 correctly, so it is generally recommended to use the
-[CLI](/enterprise/{{page.kong_version}}/developer-portal/helpers/cli/)
+[CLI](/gateway/{{page.kong_version}}/developer-portal/helpers/cli/)
 because it enforces that structure. The Portal Files API is useful for smaller
 tasks such as managing specification, content, or theme files outside the context of
 [kong-portal-templates](https://github.com/kong/kong-portal-templates).
@@ -21,10 +20,10 @@ Parameter                       | Type   | Description                | Required
 **Note:** The `@` symbol in a command automatically reads the file on disk and places
 its contents into the contents argument.
 
-### POST a Content File
+## POST a Content File
 
 For more details about content files, see the
-[Content File documentation](/enterprise/{{page.kong_version}}/developer-portal/structure-and-file-types#content-files).
+[Content File documentation](/gateway/{{page.kong_version}}/developer-portal/structure-and-file-types#content-files).
 
 {% navtabs %}
 {% navtab Using cURL %}
@@ -48,10 +47,10 @@ $ http post :8001/default/files  \
 {% endnavtabs %}
 
 
-### POST a Spec File
+## POST a Spec File
 
 For more details about specification files, see the
-[Spec File documentation](/enterprise/{{page.kong_version}}/developer-portal/structure-and-file-types#spec-files).
+[Spec File documentation](/gateway/{{page.kong_version}}/developer-portal/structure-and-file-types#spec-files).
 
 {% navtabs %}
 {% navtab Using cURL %}
@@ -75,10 +74,10 @@ $ http post :8001/default/files  \
 {% endnavtabs %}
 
 
-### POST a Theme File
+## POST a Theme File
 
 For more details about theme files, see the
-[Theme File documentation](/enterprise/{{page.kong_version}}/developer-portal/structure-and-file-types#theme-files).
+[Theme File documentation](/gateway/{{page.kong_version}}/developer-portal/structure-and-file-types#theme-files).
 
 {% navtabs %}
 {% navtab Using cURL %}
@@ -101,7 +100,7 @@ $ http post :8001/default/files  \
 {% endnavtab %}
 {% endnavtabs %}
 
-### GET a File
+## GET a File
 
 {% navtabs %}
 {% navtab Using cURL %}
@@ -120,7 +119,7 @@ $ http :8001/default/files/content/index.txt
 {% endnavtab %}
 {% endnavtabs %}
 
-### PATCH a File
+## PATCH a File
 
 {% navtabs %}
 {% navtab Using cURL %}
@@ -141,7 +140,7 @@ $ http patch :8001/default/files/content/index.txt \
 {% endnavtab %}
 {% endnavtabs %}
 
-### DELETE a File
+## DELETE a File
 
 {% navtabs %}
 {% navtab Using cURL %}

--- a/app/gateway/2.6.x/developer-portal/helpers/cli.md
+++ b/app/gateway/2.6.x/developer-portal/helpers/cli.md
@@ -1,15 +1,13 @@
 ---
 title: Developer Portal CLI
+badge: enterprise
 ---
-
-
-### Introduction
 
 The Kong Developer Portal CLI is used to manage your Developer Portals from the
 command line. It is built using [clipanion][clipanion].
 
 
-### Overview
+## Overview
 
 This is the next generation TypeScript based Developer Portal CLI. The goal of
 this project is to make a higher quality CLI tool over the initial sync script.
@@ -19,13 +17,13 @@ This project is built for Kong Enterprise `>= 1.3`.
 For Kong Enterprise `<= 0.36`, or for `legacy mode` on Kong Enterprise `>= 1.3` [use the legacy sync script][sync-script].
 
 
-### Install
+## Install
 
 ```
 > npm install -g kong-portal-cli
 ```
 
-### Usage
+## Usage
 
 The easiest way to start is by cloning the [portal-templates repo][templates]
 master branch locally.

--- a/app/gateway/2.6.x/developer-portal/index.md
+++ b/app/gateway/2.6.x/developer-portal/index.md
@@ -1,8 +1,6 @@
 ---
-title: Kong Developer Portal
-toc: false
-book: developer-portal
-chapter: 1
+title: Kong Dev Portal
+badge: enterprise
 ---
 
 The Kong Dev Portal provides a single source of truth for all developers

--- a/app/gateway/2.6.x/developer-portal/structure-and-file-types.md
+++ b/app/gateway/2.6.x/developer-portal/structure-and-file-types.md
@@ -1,13 +1,11 @@
 ---
 title: Developer Portal Structure and File Types
-book: developer-portal
-chapter: 4
+badge: enterprise
 ---
-
-## Introduction
 
 The Kong Portal templates have been completely revamped to allow for easier customization, clearer separation of concerns between content and layouts, and more powerful hooks into Kong lifecycle/data.  Under the hood, we have implemented a flat file CMS built on top of the `https://github.com/bungle/lua-resty-template` library.  This system should feel familiar for anyone who has worked with projects like `jekyll`, `kirby cms`, or `vuepress` in the past.
 
+{:.note}
 >Note: To follow along with this guide, it is best to clone the [kong-portal-templates repo](https://github.com/Kong/kong-portal-templates) and check out the `master` branch. This guide makes the assumption that you are working within a single workspace (the templates repo can host many different sets of portal files per workspace).  Navigate to the `workspaces/default` directory from root to view the default workspaces portal files.
 
 ## Directory Structure
@@ -28,14 +26,14 @@ From `workspaces/default`, you can see the different elements that make up a sin
 
 ## Portal Configuration File
 
-#### Path
+### Path
 - **format:** `portal.conf.yaml`
 - **file extensions:** `.yaml`
 
-#### Description
+### Description
 The Portal Configuration File determines which theme the portal uses to render, the name of the portal, as well as configuration for special behavior such as redirect paths for user actions like login/logout. It is required in the root of every portal. There can only be one Portal Configuration File, it must be named `portal.conf.yaml`, and it must be a direct child of the root directory.
 
-#### Example
+### Example
 
 ```yaml
 name: Kong Portal
@@ -71,19 +69,19 @@ collections:
 - `collections`
   - **required**: false
   - **type**: `object`
-  - **description**: Collections are a powerful tool enabling you to render sets of content as a group.  Content rendered as a collection share a configurable route pattern, as well as a layout. For more information check out the [collections](/enterprise/{{page.kong_version}}/developer-portal/working-with-templates/#collections) section of our [Working with Templates](/enterprise/{{page.kong_version}}/developer-portal/working-with-templates) guide.
+  - **description**: Collections are a powerful tool enabling you to render sets of content as a group.  Content rendered as a collection share a configurable route pattern, as well as a layout. For more information check out the [collections](/gateway/{{page.kong_version}}/developer-portal/working-with-templates/#collections) section of our [Working with Templates](/gateway/{{page.kong_version}}/developer-portal/working-with-templates) guide.
 
 
 ## Router Configuration File (Optional)
 
-#### Path
+### Path
 - **format:** `router.conf.yaml`
 - **file extensions:** `.yaml`
 
-#### Description
+### Description
 This optional config file overrides the portals default routing system with hardcoded values.  This is useful for implementing single page applications, as well as for setting a static site structure. There can only be one Router Configuration File, it must be named `router.conf.yaml`, and it must be a direct child of the root directory.
 
-#### Example
+### Example
 The `router.conf.yaml` file expects sets of key-value pairs. The key should be the route you want to set; the value should be the content file path you want that route to resolve to. Routes should begin with a backslash.  `/*` is a reserved route and acts as a catchall/wildcard. If the requested route is not explicitly defined in the config file, the portal will resolve to the wildcard route if present.
 
 ```yaml
@@ -94,11 +92,11 @@ The `router.conf.yaml` file expects sets of key-value pairs. The key should be t
 
 ## Content Files
 
-#### Path
+### Path
 - **format:** `content/**/*`
 - **file extensions:** `.txt`, `.md`, `.html`, `.yaml`, `.json`
 
-#### Description
+### Description
 Content files establish portal site structure, as well as provide its accompanying HTML layout with metadata and dynamic content at the time of render. Content files can be nested in as many subdirectories as desired as long as the parent directory is `content/`.
 
 In addition to providing metainfo and content for the current page at time of render, content files determine the path at which a piece of content can be accessed in the browser.
@@ -110,7 +108,7 @@ In addition to providing metainfo and content for the current page at time of re
 | `content/documentation/index.txt` | `http://portal_gui_url/documentation` |
 | `content/documentation/spec_one.txt` | `http://portal_gui_url/documentation/spec_one` |
 
-#### Contents
+### Contents
 ```
 ---
 title: homepage
@@ -123,7 +121,7 @@ Welcome to the homepage!
 
 File contents can be broken down into two parts: `headmatter` and `body`.
 
-##### headmatter
+### headmatter
 
 The first thing to notice in the example files contents are the two sets of `---` delimiters at the start.  The text contained within these markers is called `headmatter` and always gets parsed and validated as valid `yaml`.  `headmatter` contains information necessary for a file to render successfully, as well as any information you would like to access within a template.  Kong parses any valid `yaml` key-value pair and becomes available within the content's corresponding HTML template. There are a few reserved attributes that have special meaning to Kong at the time of render:
 
@@ -158,21 +156,21 @@ The first thing to notice in the example files contents are the two sets of `---
   - **type**: `string`
   - **description**: Used by `collection` config to determine custom routing.  You can read more about Collections in the collections section of the _working with templates_ guide.
 
-##### body
+#### body
 The information located under headmatter represents the content body. Body content is freeform and gets parsed as by the file extension included in the file path. In the case of the example above, the file is `.txt` and is available in the template as such.
 
 ## Spec Files
 
-#### Path
+### Path
 - **format:** `specs/**/*`
 - **file extensions:** `.yaml`, `.json`
 
-#### Description
+### Description
 Specs are similar to `content` files in that they provide the dynamic data needed to render a page, as well as any metadata a user wants to provide as `headmatter`.  The format in which these are provided to the Portal differs from `content` files, which can be seen in the example below.
 
 >It is recommended to keep spec folder structure flat. Spec files must be valid OAS or Swagger `.yaml`/`.yml` or `.json` files.
 
-#### Contents
+### Contents
 
 ```
 swagger: "2.0"
@@ -220,11 +218,11 @@ If you want to overwrite the hardcoded spec collection config, you can do so by
 including your own in `portal.conf.yaml`. Check out the Collections section of
 our `Working with Templates` guide to learn more.
 
-You can also use the [Portal Files API](/enterprise/{{page.kong_version}}/developer-portal/files-api)
+You can also use the [Portal Files API](/gateway/{{page.kong_version}}/developer-portal/files-api)
 to `POST`, `GET`, `PATCH`, and `DELETE` content, spec, and theme files.
 
 ## Theme Files
-#### Themes Directory Structure
+### Themes Directory Structure
 The theme directory contains different instances of portal themes, each one of which determines the look and feel of the developer portal via html/css/js.  Which theme is used at time of render is determined by setting `theme.name` within `portal.conf.yaml`. Setting `theme.name` to `best-theme` causes the portal to load theme files under `themes/best-theme/**`.
 
 Each theme file is composed of a few different folders:
@@ -237,12 +235,12 @@ Each theme file is composed of a few different folders:
 - **theme.conf.yaml**
   - This config file sets color and font defaults available to templates for reference as css variables. It also determines what options are available in the Kong Manager Appearance page.
 
-#### Theme Assets
+### Theme Assets
 
-##### Path
+#### Path
 - **format:** `theme/*/assets/**/*`
 
-##### Description
+#### Description
 The asset folder contains css/js/fonts/images for your templates to reference.
 
 To access asset files from your templates, keep in mind that Kong assumes a path from the root of your selected theme.
@@ -253,15 +251,15 @@ To access asset files from your templates, keep in mind that Kong assumes a path
 | `themes/light-theme/assets/js/my-script.js` | `<script src="assets/js/my-script.js"></script>` |
 | `themes/light-theme/assets/styles/my-styles.css` | `<link href="assets/styles/normalize.min.css" rel="stylesheet" />` |
 
->Note: Image files uploaded to the `theme/*/assets/` directory should either be a svg text string or `base64` encoded, 'base64` images will be decoded when served.
+>Note: Image files uploaded to the `theme/*/assets/` directory should either be a svg text string or `base64` encoded, `base64` images will be decoded when served.
 
-#### Theme Layouts
+### Theme Layouts
 
-##### Path
+#### Path
 - **format:** `theme/*/layouts/**/*`
 - **file extensions:** `.html`
 
-##### Description
+#### Description
 Layouts act as the html skeleton of the page you want to render. Each file within the layouts directory must have an `html` filetype. They can exist as vanilla `html`, or can reference partials and parent layouts via the portals templating syntax. Layouts also have access to the `headmatter` and `body` attributes set in `content`.
 
 The example below shows what a typical layout could look like.
@@ -283,15 +281,15 @@ The example below shows what a typical layout could look like.
 ```
 {% endraw %}
 
-To learn more about the templating syntax used in this example, check out our [templating guide](/enterprise/{{page.kong_version}}/developer-portal/working-with-templates).
+To learn more about the templating syntax used in this example, check out our [templating guide](/gateway/{{page.kong_version}}/developer-portal/working-with-templates).
 
-#### Theme Partials
+### Theme Partials
 
-##### Path
+#### Path
 - **format:** `theme/*/partials/**/*`
 - **file extensions:** `.html`
 
-##### Description
+#### Description
 Partials are very similar to layouts: they share the same syntax, can call other partials within themselves, and have access to the same data/helpers at time of render. The thing that differentiates partials from layouts it that layouts call on partials to build the page, but partials cannot call on layouts.
 
 The example below shows the `header.html` partial referenced from the example above:
@@ -300,7 +298,7 @@ The example below shows the `header.html` partial referenced from the example ab
 ```html
 <header>
   <div class="row">
-    <div class="column>
+    <div class="column">
       <img src="{{page.logo}}">      <- can access the same page data the parent layout
     </div>
     <div class="column">
@@ -311,11 +309,11 @@ The example below shows the `header.html` partial referenced from the example ab
 ```
 {% endraw %}
 
-#### Theme Configuration File
+### Theme Configuration File
 
-##### Path
+#### Path
 - **format:** `theme/*/theme.conf.yaml`
 - **file extensions:** `.yaml`
 
-##### Description
+#### Description
 The Theme Configuration File determines color/font/image values a theme makes available for templates/CSS at the time of render. It is required in the root of every theme. There can only be one Theme Configuration File, it must be named `theme.conf.yaml`, and it must be a direct child of the themes root directory.

--- a/app/gateway/2.6.x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -1,21 +1,20 @@
 ---
 title: Adding and Using JavaScript Assets in Kong Dev Portal
+badge: enterprise
 ---
-
-## Introduction
 
 The Kong Developer Portal ships with Vue, React, and jQuery already loaded.
 You may want to make use of these libraries to write custom interactive
 webpages or load additional JavaScript.
 
-> Note: This guide is for adding/using JavaScript assets without changing server-side routing. [Learn more about a SPA to the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/single-page-app).
+> Note: This guide is for adding/using JavaScript assets without changing server-side routing. [Learn more about a SPA to the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/theme-customization/single-page-app).
 
 ## Prerequisites
 
 * Kong Enterprise 1.3 or later
 * Portal Legacy is turned off
 * The Kong Developer Portal is enabled and running
-* The [kong-portal-cli tool](/enterprise/{{page.kong_version}}/developer-portal/helpers/cli) is installed locally
+* The [kong-portal-cli tool](/gateway/{{page.kong_version}}/developer-portal/helpers/cli) is installed locally
 
 
 ## Adding JS Assets
@@ -24,7 +23,7 @@ webpages or load additional JavaScript.
 To add JavaScript assets:
 1. Clone the [kong-portal-templates](https://github.com/Kong/kong-portal-templates) repo.
 2. Add any JavaScript files to the `themes/base/js` folder.
-3. Deploy using the [kong-portal-cli-tool](/enterprise/{{page.kong_version}}/developer-portal/helpers/cli).
+3. Deploy using the [kong-portal-cli-tool](/gateway/{{page.kong_version}}/developer-portal/helpers/cli).
 
 
 ## Loading JS Assets

--- a/app/gateway/2.6.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -1,18 +1,17 @@
 ---
 title: Easy Theme Editing in Kong Manager
+badge: enterprise
 ---
-
-### Introduction
 
 The Kong Developer Portal ships with a default theme, including preset images, background colors, fonts, and button styles. These settings can be edited quickly and easily from within Kong Manager, without the need to edit code.
 
-### Prerequisites
+## Prerequisites
 
 * Kong Enterprise 1.3 or later
 * Access to Kong Manager
 * The Developer Portal is enabled and running
 
-### The Appearance Tab
+## The Appearance Tab
 
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
@@ -29,6 +28,6 @@ Hovering over an element will show a color picker, as well as a list of predefin
 
 ## Editing Theme Files with the Editor
 
-The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor) for more information on how to edit, preview, and save files in the Editor.
+The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/gateway/{{page.kong_version}}/developer-portal/using-the-editor) for more information on how to edit, preview, and save files in the Editor.
 
 ![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/gateway/2.6.x/developer-portal/theme-customization/emails.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/emails.md
@@ -1,13 +1,9 @@
 ---
 title: Customizing Portal Emails
+badge: enterprise
 ---
 
-<div class="version-callout"><b>This feature was introduced in 1.3.0.1.</b></div>
-
-## Introduction
-
-Kong Enterprise **1.3.0.1** introduces editable Portal Emails.
-This feature allows you to manage the message and appearance of emails being sent by the Kong Developer Portal.
+You can manage the message and appearance of emails being sent by the Kong Developer Portal.
 Editable email templates are loaded as files similar to content files for portal rendering.
 Email files can be managed in the same way as other files for rendering, via editor or via the Portal CLI Tool.
 This feature is **not** supported on legacy portal mode.
@@ -25,7 +21,7 @@ Not all tokens are supported on all emails.
 * Kong Enterprise **1.3.0.1** or later
 * The Kong Developer Portal is not running in **Legacy Mode**
 * The Kong Developer Portal is enabled and running
-* [The emails you want are enabled in kong](/enterprise/{{page.kong_version}}/developer-portal/configuration/smtp/#portal_invite_email)
+* [The emails you want are enabled in kong](/gateway/{{page.kong_version}}/developer-portal/configuration/smtp/#portal_invite_email)
 * If using CLI tool, kong-portal-cli tool 1.1 or later is installed locally and git installed
 
 

--- a/app/gateway/2.6.x/developer-portal/theme-customization/markdown-extended.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/markdown-extended.md
@@ -1,12 +1,11 @@
 ---
 title: Markdown Rendering Module
+badge: enterprise
 ---
-
-## Introduction
 
 The Kong Developer Portal supports
 [Github-flavored markdown](https://github.github.com/gfm/) (GFM) that can be
-used in lieu of the [templates](/enterprise/{{page.kong_version}}/developer-portal/working-with-templates). Instead of having to
+used in lieu of the [templates](/gateway/{{page.kong_version}}/developer-portal/working-with-templates). Instead of having to
 create an HTML layout and partials for your templates, you can use custom CSS
 with the improved markdown rendering module. The extended markdown support
 improves rendering significantly, especially for tables.

--- a/app/gateway/2.6.x/developer-portal/theme-customization/single-page-app.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/single-page-app.md
@@ -1,33 +1,32 @@
 ---
 title: Hosting Single Page App out of Kong Dev Portal
+badge: enterprise
 ---
-
-### Introduction
 
 The Kong Developer Portal ships with a default server-side rendered theme; however, it is possible to replace this with a Single Page App (SPA). This example is in Angular using the Angular CLI Tool, but you can follow along with any other JavaScript framework with just a few tweaks.
 
 To view the basic example Angular template from this guide, visit the [`example/spa-angular`](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular) branch from the `kong-portal-templates branch`.
 
-### Prerequisites
+## Prerequisites
 
 * Kong Enterprise 1.3 or later
 * Portal Legacy is turned off
 * The Developer Portal is enabled and running
 * kong-portal-cli tool is installed locally
 
-### What is a SPA
+## What is a SPA
 
 A Single Page App (SPA) is a website that loads all HTML, JavaScript, and CSS on the first load. Instead of loading subsequent pages from the server, JavaScript is used to dynamically change the page content. You may want to use an SPA in Dev Portal if you have a preexisting SPA you want to integrate with the portal, or you are trying to achieve a more application-like experience across many pages. An SPA takes control of routing from the server, and handles it client-side instead.
 
-Custom JavaScript can also be added to run only on specific layouts, allowing you to maintain server-side rendering. [Learn more](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding JavaScript to a layout without implementing an SPA.
+Custom JavaScript can also be added to run only on specific layouts, allowing you to maintain server-side rendering. [Learn more](/gateway/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding JavaScript to a layout without implementing an SPA.
 
-### Making Choices
+## Making Choices
 
 
 We recommend Catalog and Spec routes not be handled by SPA.
 If you are using Authentication, then you probably also want to leave server-side rendering for any account pages.
 
-### Getting Started
+## Getting Started
 
 Clone the [portal-templates](https://github.com/Kong/kong-portal-templates) repo
 
@@ -53,7 +52,7 @@ In the `router.conf.yaml` example below, we are hardcoding routing for all kong 
 
 ```
 
-#### 1. Create your SPA
+### Create your SPA
 
 Create an SPA app in the JavaScript framework of your choice. This
 example uses angular.
@@ -76,7 +75,7 @@ Copy the build output JS and CSS files to a folder inside `workspaces/default/th
 
 For this example, place the angular build inside a `workspaces/default/themes/assets/js/ng`.
 
-#### 2. Mounting an SPA
+### Mounting an SPA
 
 In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example, call it `spa.html`.
 
@@ -121,7 +120,7 @@ This is the resulting layout:
 
 If the SPA build process creates a css file, edit the `head.html` partial to include your css file.
 
-#### 3. Loading your layout
+### Loading your layout
 
 Modify `workspaces/default/content/index.txt` to use your layout.
 The title you set here will be the one that displays until the JS set title loads.
@@ -135,7 +134,7 @@ title: Home
 ```
 {% endraw %}
 
-#### 4. Deploy the Portal
+### Deploy the Portal
 
 Now using the kong-portal-cli tool, deploy the portal.
 

--- a/app/gateway/2.6.x/developer-portal/using-the-editor.md
+++ b/app/gateway/2.6.x/developer-portal/using-the-editor.md
@@ -1,14 +1,13 @@
 ---
-title: Using the Editor
+title: Using the Editor through Kong Manager
+badge: enterprise
 ---
-
-### Introduction
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
 ![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
 
-### Prerequisites
+## Prerequisites
 
 * Kong Enterprise 1.3 or later
 * Access to Kong Manager
@@ -16,7 +15,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 >NOTE: Editor Mode is *not* available when running the Dev Portal in **legacy** mode.
 
-### Enter Editor Mode
+## Enter Editor Mode
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
@@ -28,9 +27,7 @@ This will launch the **Editor Mode**:
 ![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
 
 
-
-
-### Navigating the Editor
+## Navigating the Editor
 
 When enabled, the Dev Portal is pre-populated with Kong's default theme. The file editor exposes these files to the UI, allowing them to be edited quickly and easily from inside the browser. When you first open the editor, you will be presented with a list of files on the left, and a blank editing form.
 
@@ -42,15 +39,14 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 
 ![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
 
-### Editing Files
+## Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
 ![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
 
 
-
-### Adding new files
+## Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
 
@@ -59,7 +55,7 @@ Clicking the `New File +` button opens the New File Dialog.
 Once created, files will immediately be available from within the Editor.
 
 
-### Authenticating files
+## Authenticating files
 
 Authentication is handled by `readable_by` value on content pages (for gui view, go to permissions page)
     - set readable_by: '*' to equal old authenticated
@@ -67,7 +63,7 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
     - on specs, readable_by is set inside "x-headmatter" object
 
 
-### Deleting files
+## Deleting files
 
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 

--- a/app/gateway/2.6.x/developer-portal/working-with-templates.md
+++ b/app/gateway/2.6.x/developer-portal/working-with-templates.md
@@ -1,12 +1,11 @@
 ---
 title: Working with Templates
+badge: enterprise
 ---
 
-### Introduction
+Kong Portal is built on top of the `lua-resty-template` templating library, which can be viewed here: [https://github.com/bungle/lua-resty-template](https://github.com/bungle/lua-resty-template). Basic usage of the library will be described below. Refer to the source documentation for a more in-depth look at what it can accomplish.
 
-Kong Portal 1.3 is built on top of the `lua-resty-template` templating library, which can be viewed here: [https://github.com/bungle/lua-resty-template](https://github.com/bungle/lua-resty-template). Basic usage of the library will be described below. Refer to the source documentation for a more in-depth look at what it can accomplish.
-
-### Syntax
+## Syntax
 ***(excerpt from lua-resty-templates documentation)***
 
 You may use the following tags in templates:
@@ -21,11 +20,11 @@ You may use the following tags in templates:
 * `{# comments #}` everything between `{#` and `#}` is considered to be commented out (i.e., not outputted or executed).
 {% endraw %}
 
-### Using Partials
+## Partials
 
 Partials are snippets of html that layouts can reference. Partials have access to all the same data that its layout does, and can even call other partials.  Breaking your code into partials can help organize large pages, as well as allow different layouts share common page elements.
 
-##### content/index.txt
+### content/index.txt
 
 {% raw %}
 ```
@@ -44,7 +43,7 @@ hero_description: Partials are wicked sick!
 ```
 {% endraw %}
 
-##### layouts/index.html
+### layouts/index.html
 
 {% raw %}
 ```html
@@ -56,7 +55,7 @@ hero_description: Partials are wicked sick!
 ```
 {% endraw %}
 
-##### partials/header.html
+### partials/header.html
 
 {% raw %}
 ```html
@@ -71,7 +70,7 @@ hero_description: Partials are wicked sick!
 ```
 {% endraw %}
 
-##### partials/header_nav.html
+### partials/header_nav.html
 
 {% raw %}
 ``` html
@@ -83,7 +82,7 @@ hero_description: Partials are wicked sick!
 ```
 {% endraw %}
 
-##### partials/hero.html
+### partials/hero.html
 
 {% raw %}
 ``` html
@@ -93,7 +92,7 @@ hero_description: Partials are wicked sick!
 {% endraw %}
 
 
-##### partials/hero.html
+### partials/hero.html
 
 {% raw %}
 ``` html
@@ -104,7 +103,7 @@ hero_description: Partials are wicked sick!
 {% endraw %}
 
 
-##### Output
+Output:
 
 {% raw %}
 ```html
@@ -127,13 +126,13 @@ hero_description: Partials are wicked sick!
 ```
 {% endraw %}
 
-### Using Blocks
+## Blocks
 
 Blocks can be used to embed a view or partial into another template. Blocks are particularly useful when you want different templates to share a common wrapper.
 
 In the example below, notice that the content file is referencing `index.html`, and not `wrapper.html`.
 
-##### content/index.txt
+### content/index.txt
 
 {% raw %}
 ```markdown
@@ -146,7 +145,7 @@ description: Blocks are the future!
 {% endraw %}
 
 
-##### layouts/index.html
+### layouts/index.html
 
 {% raw %}
 ```html
@@ -161,7 +160,7 @@ description: Blocks are the future!
 ```
 {% endraw %}
 
-##### layouts/wrapper.html
+### layouts/wrapper.html
 
 {% raw %}
 ```html
@@ -183,7 +182,7 @@ description: Blocks are the future!
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 {% raw %}
 ```html
@@ -208,7 +207,7 @@ description: Blocks are the future!
 ```
 {% endraw %}
 
-### collections
+## Collections
 Collections are a powerful tool enabling you to render sets of content as a group.  Content rendered as a collection share a configurable route pattern, as well as a layout. Collections are configured in your portals `portal.conf.yaml` file.
 
 The example below shows all the necessary configuration/files needed to render a basic `blog` collection made up of individual `posts`.
@@ -231,11 +230,11 @@ collections:
 Above you can see a `collections` object was declared, which is made up of individual collection configurations. In this example, you are configuring a collection called `posts`.  The renderer looks for a root directory called `_posts` within the `content` folder for individual pages to render.  If you created another collection conf called `animals`, the renderer would look for a directory called `_animals` for content files to render.
 
 Each configuration item is made up of a few parts:
-- ###### `output`
+- `output`
   - **required**: false
   - **type**: `boolean`
   - **description**: This optional attribute determines whether the collections should render or not. When set to `false`, virtual routes for the collection are not created.
-- ###### `route`
+- `route`
   - **required**: true
   - **type**: `string`
   - **default**: `none`
@@ -246,12 +245,12 @@ Each configuration item is made up of a few parts:
       - `:name`: Replaces namespace with the filename of a piece of content.
       - `:collection`: Replaces namespace with name of current collection.
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
-- ###### `route`
+- `layout`
     - **required**: true
       - **type**: `boolean`
       - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
-##### `content/_posts/post1.md`
+### `content/_posts/post1.md`
 
 {% raw %}
 ```
@@ -265,7 +264,7 @@ This is my first post!
 {% endraw %}
 
 
-##### `content/_posts/post2.md`
+### `content/_posts/post2.md`
 
 {% raw %}
 ```
@@ -278,7 +277,7 @@ This is my second post!
 ```
 {% endraw %}
 
-##### `themes/base/layouts/post.html`
+### `themes/base/layouts/post.html`
 
 {% raw %}
 ```html
@@ -287,16 +286,16 @@ This is my second post!
 ```
 {% endraw %}
 
-#### Output:
+Output:
 
-##### `<kong_portal_gui_url>/blog/posts/post1`
+From `<kong_portal_gui_url>/blog/posts/post1`:
 
 ```html
 <h1>Post One</h1>
 <p>This is my first post!</p>
 ```
 
-##### `<kong_portal_gui_url>/blog/posts/post2`
+From `<kong_portal_gui_url>/blog/posts/post2`:
 
 ```html
 <h1>Post Two</h1>
@@ -304,13 +303,10 @@ This is my second post!
 ```
 
 
-### List of Helper Functions
-
-# Kong Template Helpers - Lua API
+## Kong Template Helpers - Lua API
 Kong Template Helpers are a collection of objects that give access to your portal data at the time of render and provide powerful integrations into Kong.
 
-
-## Globals
+Globals:
 
 - [`l`](#lkey-fallback) - Locale helper, first version, gets values from the currently active page.
 - [`each`](#eachlist_or_table) - Commonly used helper to iterate over lists or tables.
@@ -319,8 +315,7 @@ Kong Template Helpers are a collection of objects that give access to your porta
 - [`json_decode`](#json_decode) - Decode JSON to Lua table.
 - [`json_encode`](#json_encode) - Encode Lua table to JSON.
 
-
-## Objects
+Objects:
 
 - [`portal`](#portal) - The portal object refers to the current workspace portal being accessed.
 - [`page`](#page) - The page object refers to the currently active page and its contents.
@@ -331,17 +326,14 @@ Kong Template Helpers are a collection of objects that give access to your porta
 - [`helpers`](#helpers) - Helper functions simplify common tasks or provide easy shortcuts to Kong Portal methods.
 
 
-## Terminology / Definitions
+Terminology / Definitions:
 
 - `list` - Also referred to commonly as an array (`[1, 2, 3]`) in Lua is a table-like object (`{1, 2, 3}`). Lua list index starts at `1` not `0`. Values can be accessed by array notation (`list[1]`).
 - `table` - Also commonly known as an object or hashmap (`{1: 2}`) in Lua looks like (`{1 = 2}`). Values can be accessed by array or dot notation (`table.one or table["one"]`).
 
-# Globals
-## `l(key, fallback)`
+### `l(key, fallback)`
 
-#### Description
-
-> Returns the current translation by key from the currently active page.
+Returns the current translation by key from the currently active page.
 
 #### Return Type
 {% raw %}
@@ -350,10 +342,10 @@ Kong Template Helpers are a collection of objects that give access to your porta
 string
 ```
 {% endraw %}
+
 #### Usage
 
-
-##### `content/en/example.txt`
+Using `content/en/example.txt`:
 
 {% raw %}
 ```yaml
@@ -368,7 +360,7 @@ locale:
 {% endraw %}
 
 
-##### `content/es/example.txt`
+Using `content/es/example.txt`:
 
 {% raw %}
 ```yaml
@@ -383,7 +375,7 @@ locale:
 {% endraw %}
 
 
-##### `layouts/example.html`
+Using `layouts/example.html`:
 
 {% raw %}
 ```lua
@@ -394,7 +386,9 @@ locale:
 {% endraw %}
 
 
-##### Output when on `en/example`
+Output:
+
+For `en/example`:
 
 {% raw %}
 ```html
@@ -405,7 +399,7 @@ locale:
 {% endraw %}
 
 
-##### Output when on `es/example`
+For `es/example`:
 
 {% raw %}
 ```html
@@ -420,11 +414,9 @@ locale:
 
 - `l(...)` is a helper from the `page` object. It can be also accessed via `page.l`. However, `page.l` does not support template interpolation (for example, `{{portal.name}}` will not work.)
 
-## `each(list_or_table)`
+### `each(list_or_table)`
 
-#### Description
-
-> Returns the appropriate iterator depending on what type of argument is passed.
+Returns the appropriate iterator depending on what type of argument is passed.
 
 #### Return Type
 
@@ -434,7 +426,7 @@ Iterator
 
 #### Usage
 
-##### Template (List)
+Template (List):
 
 {% raw %}
 ```lua
@@ -448,7 +440,7 @@ Iterator
 {% endraw %}
 
 
-##### Template (Table)
+Template (Table):
 
 {% raw %}
 ```lua
@@ -461,11 +453,9 @@ Iterator
 ```
 {% endraw %}
 
-## `print(any)`
+### `print(any)`
 
-#### Description
-
-> Returns stringified output of input value.
+Returns stringified output of input value.
 
 #### Return Type
 
@@ -475,7 +465,7 @@ string
 
 #### Usage
 
-##### Template (Table)
+Template (Table):
 
 {% raw %}
 ```lua
@@ -483,11 +473,9 @@ string
 ```
 {% endraw %}
 
-## `markdown(string)`
+### `markdown(string)`
 
-#### Description
-
-> Returns HTML from the markdown string passed as an argument. If a string argument is not valid markdown, the function will return the string as is. To render properly, the helper should be used with raw "{* *}" delimiters.
+Returns HTML from the markdown string passed as an argument. If a string argument is not valid markdown, the function will return the string as is. To render properly, the helper should be used with raw `{* *}` delimiters.
 
 #### Return Type
 
@@ -497,7 +485,7 @@ string
 
 #### Usage
 
-##### Template (string as arg)
+Template (string as arg):
 
 {% raw %}
 ```lua
@@ -505,7 +493,7 @@ string
 ```
 {% endraw %}
 
-##### Template (content val as arg)
+Template (content val as arg):
 
 {% raw %}
 ```lua
@@ -513,11 +501,9 @@ string
 ```
 {% endraw %}
 
-## `json_encode(object)`
+### `json_encode(object)`
 
-#### Description
-
-> JSON encodes Lua table passed as argument
+JSON encodes Lua table passed as argument
 
 #### Return Type
 
@@ -527,7 +513,7 @@ string
 
 #### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```lua
@@ -535,11 +521,9 @@ string
 ```
 {% endraw %}
 
-## `json_decode(string)`
+### `json_decode(string)`
 
-#### Description
-
-> Decodes JSON string argument to Lua table
+Decodes JSON string argument to Lua table
 
 #### Return Type
 
@@ -549,7 +533,7 @@ table
 
 #### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```lua
@@ -557,15 +541,10 @@ table
 ```
 {% endraw %}
 
+### `portal`
 
-# `portal`
+`portal` gives access to data relating to the current portal, this includes things like portal configuration, content, specs, and layouts.
 
-> `portal` gives access to data relating to the current portal, this includes things like portal configuration, content, specs, and layouts.
-
----
-
-- [How To Access Config Values](#how-to-access-config-values)
-- [Portal Members](#portal-members)
   - [`portal.workspace`](#portalworkspace)
   - [`portal.url`](#portalurl)
   - [`portal.api_url`](#portalapi_url)
@@ -574,9 +553,6 @@ table
   - [`portal.specs_by_tag`](#portalspecs_by_tag)
   - [`portal.developer_meta_fields`](#portaldeveloper_meta_fields)
 
----
-
-## How To Access Config Values
 
 You can access the current workspace's portal config directly on the `portal` object like so:
 
@@ -586,29 +562,25 @@ portal[config_key] or portal.config_key
 
 For example `portal.auth` is a portal config value. You can find a list of config values by reading the portal section of `kong.conf`.
 
-### From `kong.conf`
+#### From `kong.conf`
 
 The portal only exposes config values that start with  `portal_`, and they can be access by removing the `portal_` prefix.
 
-> Some configuration values are modified or customized, these customizations are documented under the [Portal Members](#portal-members) section.
+Some configuration values are modified or customized, these customizations are documented under the [Portal Members](#portal-members) section.
 
-## Portal Members
+##### `portal.workspace`
 
-### `portal.workspace`
+Returns the current portal's workspace.
 
-#### Description
-
-> Returns the current portal's workspace.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -616,27 +588,25 @@ string
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 default
 ```
 
-### `portal.url`
+#### `portal.url`
 
-#### Description
+Returns the current portal's url with workspace.
 
-> Returns the current portal's url with workspace.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -644,28 +614,26 @@ string
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 http://127.0.0.1:8003/default
 ```
 
-## `portal.api_url`
+#### `portal.api_url`
 
-#### Description
+Returns the configuration value for `portal_api_url` with
+the current workspace appended.
 
-> Returns the configuration value for `portal_api_url` with
-> the current workspace appended.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string or nil
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -673,29 +641,27 @@ string or nil
 ```
 {% endraw %}
 
-##### Output when `portal_api_url = http://127.0.0.1:8004`
+Output when `portal_api_url = http://127.0.0.1:8004`:
 
 ```html
 http://127.0.0.1:8004/default
 ```
 
-### `portal.auth`
+#### `portal.auth`
 
-#### Description
+Returns the current portal's authentication type.
 
-> Returns the current portal's authentication type.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-#### Printing Value
+**Printing a value**
 
-###### Input
+Input:
 
 {% raw %}
 ```hbs
@@ -703,15 +669,15 @@ string
 ```
 {% endraw %}
 
-###### Output when `portal_auth = basic-auth`
+Output when `portal_auth = basic-auth`:
 
 ```html
 basic-auth
 ```
 
-#### Checking Authentication Enabled
+**Checking if authentication is enabled**
 
-###### Input
+Input:
 
 {% raw %}
 ```hbs
@@ -721,29 +687,27 @@ basic-auth
 ```
 {% endraw %}
 
-###### Output when `portal_auth = basic-auth`
+Output when `portal_auth = basic-auth`:
 
 ```html
 Authentication is endabled!
 ```
 
-### `portal.specs`
-
-#### Description
+#### `portal.specs`
 
 Returns an array of specification files contained within the current portal.
 
-#### Return type
+##### Return type
 
 ```lua
 array
 ```
 
-#### Usage
+##### Usage
 
-##### Viewing content value
+**Viewing a content value**
 
-###### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -751,7 +715,7 @@ array
 ```
 {% endraw %}
 
-###### Output
+Output:
 
 ```lua
 {
@@ -767,9 +731,9 @@ array
 }
 ```
 
-##### Looping through values
+**Looping through values**
 
-###### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -779,16 +743,16 @@ array
 ```
 {% endraw %}
 
-###### Output
+Output:
 
 ```hbs
   <li>content/example1_spec.json</li>
   <li>content/documentation/example1_spec.json</li>
 ```
 
-##### Filter by path
+**Filter by path**
 
-###### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -797,15 +761,14 @@ array
 {% end %}
 ```
 {% endraw %}
-###### Output
+
+Output:
 
 ```hbs
   <li>content/documentation/example1_spec.json</li>
 ```
 
-### `portal.developer_meta_fields`
-
-#### Description
+#### `portal.developer_meta_fields`
 
 Returns an array of developer meta fields available/required by Kong to register a developer.
 
@@ -815,11 +778,11 @@ Returns an array of developer meta fields available/required by Kong to register
 array
 ```
 
-#### Usage
+##### Usage
 
-##### Printing
+**Printing a value**
 
-###### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -827,7 +790,7 @@ array
 ```
 {% endraw %}
 
-###### Output
+Output:
 
 {% raw %}
 ```lua
@@ -843,9 +806,9 @@ array
 ```
 {% endraw %}
 
-#### Looping
+**Looping through values**
 
-###### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -860,7 +823,7 @@ array
 ```
 {% endraw %}
 
-###### Output
+Output:
 
 ```html
 <ul>
@@ -872,22 +835,14 @@ array
 ...
 ```
 
-# `page`
+### `page`
 
-> `page` gives access to data relating to the current page, which includes things like page url, path, breadcrumbs, and more.
+`page` gives access to data relating to the current page, which includes things like page url, path, breadcrumbs, and more.
 
----
-
-- [How to access content values](#how-to-access-content-values)
-- [Page Members](#page-members)
   - [`page.route`](#pageroute)
   - [`page.url`](#pageurl)
   - [`page.breadcrumbs`](#pagebreadcrumbs)
   - [`page.body`](#pagebody)
-  - [`page.parsed_body`](#parsedbody)
----
-
-## How to access content values
 
 When you create a new content page, you are able to define key-values. Here you are going to learn how to access those values and a few other interesting things.
 
@@ -905,28 +860,25 @@ You can also access nested keys like so:
 page.key_name.nested_key
 ```
 {% raw %}
-> Be careful! To avoid output errors, make sure that the `key_name` exists before accessing `nested_key` as shown below:
-> ```hbs
-> {{page.key_name and page.key_name.nested_key}}
-> ```
+Be careful! To avoid output errors, make sure that the `key_name` exists before accessing `nested_key` as shown below:
+```hbs
+{{page.key_name and page.key_name.nested_key}}
+```
 {% endraw %}
 
-## Page Members
-### `page.route`
+#### `page.route`
 
-#### Description
+Returns the current page's route/path.
 
-> Returns the current page's route/path.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -934,27 +886,25 @@ string
 ```
 {% endraw %}
 
-##### Output given url is `http://127.0.0.1:8003/default/guides/getting-started`
+Output, given url is `http://127.0.0.1:8003/default/guides/getting-started`:
 
 ```html
 guides/getting-started
 ```
 
-### `page.url`
+#### `page.url`
 
-#### Description
+Returns the current page's url.
 
-> Returns the current page's url.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -962,34 +912,32 @@ string
 ```
 {% endraw %}
 
-##### Output given url is `http://127.0.0.1:8003/default/guides/getting-started`
+Output, given url is `http://127.0.0.1:8003/default/guides/getting-started`:
 
 ```html
 http://127.0.0.1:8003/default/guides/getting-started
 ```
 
-### `page.breadcrumbs`
+#### `page.breadcrumbs`
 
-#### Description
+Returns the current page's breadcrumb collection.
 
-> Returns the current page's breadcrumb collection.
-
-#### Return Type
+##### Return Type
 
 ```lua
 table[]
 ```
 
-#### Item Properties
+##### Item Properties
 
 - `item.path` - Full path to item, no forward-slash prefix.
 - `item.display_name` - Formatted name.
 - `item.is_first` - Is this the first item in the list?
 - `item.is_last` - Is this the last item in the list?
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -1006,87 +954,82 @@ table[]
 ```
 {% endraw %}
 
-### `page.body`
+#### `page.body`
 
-#### Description
+Returns the body of the current page as a string. If the route's content file has a `.md` or `.markdown` extension, the body will be parsed from markdown to html.
 
-> Returns the body of the current page as a string. If the route's content file has a `.md` or `.markdown` extension, the body will be parsed from markdown to html.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage for .txt, .json, .yaml, .yml templates
+##### Usage for .txt, .json, .yaml, .yml templates
 
-##### index.txt
+`index.txt`:
+
 ```hbs
 This is text content.
 ```
 
+Template:
 {% raw %}
-##### Template
 ```hbs
 <h1>This is a title</h1>
 <p>{{ page.body) }}</p>
 ```
 {% endraw %}
 
-##### Output
+Output:
+```
 > # This is a title
 > This is text content.
+```
 
-#### Usage for .md, .markdown templates
+##### Usage for .md, .markdown templates
 
-##### Template (markdown)
-You must use the raw delimiter syntax `{* *}` to render markdown within a template.
+Template (markdown):
+Use the raw delimiter syntax `{* *}` to render markdown within a template.
 
-##### index.txt
+`index.txt`
 ```hbs
 # This is a title
 This is text content.
 ```
 
-##### Template
+Template:
 ```hbs
 {* page.body *}
 ```
 
-##### Output
+Output:
+```
 > # This is a title
 > This is text content.
+```
 
-# `user`
+### `user`
 
-> `user` gives access to data relating to the currently authenticated user.  User object is only applicable when `KONG_PORTAL_AUTH` is enabled.
+`user` gives access to data relating to the currently authenticated user.  User object is only applicable when `KONG_PORTAL_AUTH` is enabled.
 
----
-
-- [User Members](#user-members)
   - [`user.is_authenticated`](#useris_authenticated)
   - [`user.has_role`](#userhas_role)
   - [`user.get`](#userget)
 
----
 
-## User Members
+#### `user.is_authenticated`
 
-### `user.is_authenticated`
+Returns `boolean` value as to the current user's authentication status.
 
-#### Description
-
-> Returns `boolean` value as to the current user's authentication status.
-
-#### Return Type
+##### Return Type
 
 ```lua
 boolean
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -1094,27 +1037,25 @@ boolean
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 true
 ```
 
-### `user.has_role`
+#### `user.has_role`
 
-#### Description
+Returns `true` if a user has a role given as an argument.
 
-> Returns `true` if a user has a role given as an argument.
-
-#### Return Type
+##### Return Type
 
 ```lua
 boolean
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -1122,27 +1063,25 @@ boolean
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 true
 ```
 
-### `user.get`
+#### `user.get`
 
-#### Description
+Takes developer attribute as an argument and returns value if present.
 
-> Takes developer attribute as an argument and returns value if present.
-
-#### Return Type
+##### Return Type
 
 ```lua
 any
 ```
 
-#### Usage
+##### Usage
 
-##### Template
+Template:
 
 {% raw %}
 ```hbs
@@ -1151,7 +1090,7 @@ any
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 example123@konghq.com
@@ -1159,37 +1098,30 @@ example123@konghq.com
 ```
 
 
-# `theme`
+### `theme`
 
-> The `theme` object exposes values set in your `theme.conf.yaml` file.  In addition, any variable overrides contained in `portal.conf.yaml` will be included as well.
+The `theme` object exposes values set in your `theme.conf.yaml` file.  In addition, any variable overrides contained in `portal.conf.yaml` will be included as well.
 
----
-
-- [Theme Members](#theme-members)
   - [`theme.colors`](#usercolors)
   - [`theme.color`](#usercolor)
   - [`theme.fonts`](#userfonts)
   - [`theme.font`](#userfont)
 
----
 
-## Theme Members
+#### `theme.colors`
 
-### `theme.colors`
+Returns a table of color variables and their values as key-value pairs.
 
-#### Description
-
-> Returns a table of color variables and their values as key-value pairs.
-
-#### Return Type
+##### Return Type
 
 ```lua
 table
 ```
 
-#### Usage
+##### Usage
 
-##### theme.conf.yaml
+`theme.conf.yaml`:
+
 ```yaml
 name: Kong
 colors:
@@ -1204,7 +1136,7 @@ colors:
     description: 'Tertiary Color'
 ```
 
-##### Template
+Template:
 
 {% raw %}
 ```lua
@@ -1214,7 +1146,7 @@ colors:
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 <p>primary: #FFFFFF</p>
@@ -1222,21 +1154,22 @@ colors:
 <p>tertiary: #1DBAC2</p>
 ```
 
-### `theme.color`
+#### `theme.color`
 
-#### Description
+Description
 
-> Takes color var by string argument, returns value.
+Takes color var by string argument, returns value.
 
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-##### theme.conf.yaml
+`theme.conf.yaml`:
+
 ```yaml
 name: Kong
 colors:
@@ -1251,7 +1184,7 @@ colors:
     description: 'Tertiary Color'
 ```
 
-##### Template
+Template:
 
 {% raw %}
 ```lua
@@ -1261,7 +1194,7 @@ colors:
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 <p>primary: #FFFFFF</p>
@@ -1270,21 +1203,20 @@ colors:
 ```
 
 
-### `theme.fonts`
+#### `theme.fonts`
 
-#### Description
+Returns table of font vars and their values as key-value pairs.
 
-> Returns table of font vars and their values as key-value pairs.
-
-#### Return Type
+##### Return Type
 
 ```lua
 table
 ```
 
-#### Usage
+##### Usage
 
-##### theme.conf.yaml
+`theme.conf.yaml`:
+
 ```yaml
 name: Kong
 fonts:
@@ -1293,7 +1225,7 @@ fonts:
   headings: Lato
 ```
 
-##### Template
+Template:
 
 {% raw %}
 ```lua
@@ -1303,7 +1235,7 @@ fonts:
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 <p>base: Roboto</p>
@@ -1311,21 +1243,20 @@ fonts:
 <p>headings: Lato</p>
 ```
 
-### `theme.font`
+#### `theme.font`
 
-#### Description
+Takes font name by string argument, returns value.
 
-> Takes font name by string argument, returns value.
-
-#### Return Type
+##### Return Type
 
 ```lua
 string
 ```
 
-#### Usage
+##### Usage
 
-##### theme.conf.yaml
+`theme.conf.yaml`:
+
 ```yaml
 name: Kong
 fonts:
@@ -1334,7 +1265,7 @@ fonts:
   headings: Lato
 ```
 
-##### Template
+Template:
 
 {% raw %}
 ```lua
@@ -1344,7 +1275,7 @@ fonts:
 ```
 {% endraw %}
 
-##### Output
+Output:
 
 ```html
 <p>base: #FFFFFF</p>
@@ -1352,16 +1283,15 @@ fonts:
 <p>headings: #1DBAC2</p>
 ```
 
-## `str`
+### `str`
 
-#### Description
-
-> Table containing useful string helper methods.
+Table containing useful string helper methods.
 
 #### Usage
 
+`.upper()` example:
+
 {% raw %}
-##### _.upper()_ example
 ```lua
 <pre>{{ str.upper("dog") }}</pre>
 ```
@@ -1415,15 +1345,13 @@ fonts:
 ##### str.[quote_string](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#quote_string)
 
 
-## `tbl`
+### `tbl`
 
-#### Description
-
-> Table containing useful table helper methods
+Table containing useful table helper methods
 
 #### Usage
 
-##### _.map()_ example
+`.map()` example:
 {% raw %}
 ```lua
 {% tbl.map({"dog", "cat"}, function(item) %}

--- a/app/gateway/2.6.x/get-started/comprehensive/dev-portal.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/dev-portal.md
@@ -7,7 +7,7 @@ Dev Portal provides a single source of truth for all developers to locate, acces
 
 ## Before you begin
 
-Make sure the Dev Portal is on. You should have enabled it during [installation](/enterprise/latest/deployment/installation/overview/).
+Make sure the Dev Portal is on. You should have enabled it during [installation](/gateway/{{page.kong_version}}/install-and-run).
 
 ## Enable the Dev Portal for a Workspace
 
@@ -46,11 +46,11 @@ This will expose the Dev Portal at `http://<admin-hostname>:8003/SecureWorkspace
 
 After the Dev Portal is enabled for the Workspace, a few new links appear in the left navigation menu. It may take a few seconds for the Settings page to populate.
 
-You can learn more about personalization in the [the Dev Portal documentation](/enterprise/latest/developer-portal/), including:
+You can learn more about personalization in the [the Dev Portal documentation](/gateway/{{page.kong_version}}/developer-portal/), including:
 
-* [Customizing the look and feel of the site and editor](/enterprise/latest/developer-portal/theme-customization/easy-theme-editing/)
-* [Managing access](/enterprise/latest/developer-portal/administration/)
-* [Configuring the Dev Portal](/enterprise/latest/developer-portal/configuration/)
+* [Customizing the look and feel of the site and editor](/gateway/{{page.kong_version}}/developer-portal/theme-customization/easy-theme-editing/)
+* [Managing access](/gateway/{{page.kong_version}}/developer-portal/administration/)
+* [Configuring the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/)
 
 ## Access and Interact with the Dev Portal
 
@@ -83,7 +83,7 @@ In this section, you’re going to add a new spec, the *Kong Vitals API*, to the
 
     The editor creates the file and prepares it for editing. Since you haven’t added any content to the file, the preview displays “Unable to render this definition”.
 
-5. In another tab, open the [Kong Vitals Overview page](/enterprise/latest/vitals/overview/#using-vitals-api) to download the `vitalsSpec.yaml.` Open it in your favorite text editor and copy the contents of the file.
+5. In another tab, open the [Kong Vitals Overview page](/gateway/{{page.kong_version}}/vitals/#using-vitals-api) to download the `vitalsSpec.yaml.` Open it in your favorite text editor and copy the contents of the file.
 
 6. In the Dev Portal editor, clear the contents of the editor, then paste the contents of `vitalsSpec.yaml`.
 

--- a/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
@@ -5,7 +5,7 @@ title: Expose your Services with Kong Gateway
 In this topic, you’ll learn how to expose your Services using Routes.
 
 If you are following the Getting Started workflow, make sure you have completed
-[Prepare to Administer {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/prepare)
+[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare)
 before moving on.
 
 If you are not following the Getting Started workflow, make sure you have
@@ -68,7 +68,7 @@ The service is created, and the page automatically redirects back to the
 {% navtab Using decK (YAML) %}
 
 1. In the `kong.yaml` file you exported in
-[Prepare to Administer {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration),
+[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
 define a Service with the name `example_service` and the URL
 `http://mockbin.org`:
 
@@ -331,4 +331,4 @@ sent to `http://mockbin.org`.
 * Abstracted a backend/upstream service and put a route of your choice on the
 front end, which you can now give to clients to make requests.
 
-Next, go on to learn about [enforcing rate limiting](/getting-started-guide/{{page.kong_version}}/protect-services).
+Next, go on to learn about [enforcing rate limiting](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services).

--- a/app/gateway/2.6.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/improve-performance.md
@@ -4,7 +4,7 @@ title: Improve Performance with Proxy Caching
 
 In this topic, you’ll learn how to use proxy caching to improve response efficiency using the Proxy Caching plugin.
 
-If you are following the getting started workflow, make sure you have completed [Protect your Services](/getting-started-guide/{{page.kong_version}}/protect-services) before continuing.
+If you are following the getting started workflow, make sure you have completed [Protect your Services](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services) before continuing.
 
 ## What is Proxy Caching?
 
@@ -197,4 +197,4 @@ In this section, you:
 * Set up the Proxy Caching plugin, then accessed the `/mock` route multiple times to see caching in effect.
 * Witnessed the performance differences in latency with and without caching.
 
-Next, you’ll learn about [securing services](/getting-started-guide/{{page.kong_version}}/secure-services).
+Next, you’ll learn about [securing services](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services).

--- a/app/gateway/2.6.x/get-started/comprehensive/index.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/index.md
@@ -71,9 +71,9 @@ Note the following before you start using this guide:
 
 ### Installation
 
-* This guide assumes that you have [{{site.ce_product_name}}](https://konghq.com/install/)
-or [{{site.base_gateway}}](/enterprise/latest/deployment/installation/overview/)
-installed and running on the platform of your choice.
+* This guide assumes that you have {{site.ce_product_name}}
+or {{site.base_gateway}}
+[installed and running](/gateway/{{page.kong_version}}/install-and-run/) on the platform of your choice.
 * During your installation, take note of the `KONG_PASSWORD`; you’ll need it
 later on in this guide for setting up user authorization.
 
@@ -106,4 +106,4 @@ common to both {{site.ce_product_name}} and {{site.base_gateway}}.
 
 ### Next Steps
 
-Next, [prepare to administer {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/prepare).
+Next, [prepare to administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare).

--- a/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
@@ -4,7 +4,7 @@ title: Set Up Intelligent Load Balancing
 
 In this topic, you’ll learn about configuring upstream services, and create multiple targets for load balancing.
 
-If you are following the getting started workflow, make sure you have completed [Secure Services Using Authentication](/getting-started-guide/{{page.kong_version}}/secure-services) before moving on.
+If you are following the getting started workflow, make sure you have completed [Secure Services Using Authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services) before moving on.
 
 ## What are Upstreams?
 
@@ -196,4 +196,4 @@ In this topic, you:
 * Created an Upstream object named `upstream` and pointed the Service `example_service` to it.
 * Added two targets, `httpbin.org` and `mockbin.org`, with equal weight to the Upstream.
 
-If you have a {{site.konnect_product_name}} subscription, go on to [Managing Administrative Teams](/getting-started-guide/{{page.kong_version}}/manage-teams).
+If you have a {{site.konnect_product_name}} subscription, go on to [Managing Administrative Teams](/gateway/{{page.kong_version}}/get-started/comprehensive/manage-teams).

--- a/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
@@ -5,7 +5,7 @@ badge: enterprise
 
 In this topic, you’ll learn how to manage and configure user authorization using workspaces and teams in {{site.base_gateway}}.
 
-If you are following the getting started workflow, make sure you have completed [Set Up Intelligent Load Balancing](/getting-started-guide/{{page.kong_version}}/load-balancing) before moving on.
+If you are following the getting started workflow, make sure you have completed [Set Up Intelligent Load Balancing](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing) before moving on.
 
 ## Overview of workspaces and Teams
 
@@ -178,7 +178,7 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 {% navtab Using the Admin API %}
 
 <div class="alert alert-warning">
-<strong>Note:</strong> The following method refers to the <em>/users</em> endpoint and creates an Admin API user that won't be visible (or manageable) through Kong Manager. If you want to later administer the admin through Kong Manager, create it under the <a href="/enterprise/latest/admin-api/admins/reference/"><em>/admins</em> endpoint</a> instead.
+<strong>Note:</strong> The following method refers to the <em>/users</em> endpoint and creates an Admin API user that won't be visible (or manageable) through Kong Manager. If you want to later administer the admin through Kong Manager, create it under the <a href="/gateway/{{page.kong_version}}/admin-api/admins/reference/"><em>/admins</em> endpoint</a> instead.
 </div>
 
 Create a new user named `secureworkspaceadmin` with the RBAC token
@@ -366,4 +366,4 @@ In this topic, you:
 * Created a workspace named `SecureWorkspace`.
 * Created an admin named `secureworkspaceadmin` and granted them permissions to manage to everything in the `SecureWorkspace`.
 
-Next, set up the [Dev Portal](/getting-started-guide/{{page.kong_version}}/dev-portal).
+Next, set up the [Dev Portal](/gateway/{{page.kong_version}}/get-started/comprehensive/dev-portal).

--- a/app/gateway/2.6.x/get-started/comprehensive/prepare.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/prepare.md
@@ -155,4 +155,4 @@ The output shows all of the connected Data Plane instances in the cluster:
 
 In this section, you learned about the methods of administering
 {{site.base_gateway}} and how to access its configuration. Next, go on to
-learn about [exposing your services with {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/expose-services).
+learn about [exposing your services with {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/expose-services).

--- a/app/gateway/2.6.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/protect-services.md
@@ -3,7 +3,7 @@ title: Protect your Services
 ---
 In this topic, you’ll learn how to enforce rate limiting using the Rate Limiting plugin.
 
-If you are following the getting started workflow, make sure you have completed [Exposing Your Services](/getting-started-guide/{{page.kong_version}}/expose-services) before moving on.
+If you are following the getting started workflow, make sure you have completed [Exposing Your Services](/gateway/{{page.kong_version}}/get-started/comprehensive/expose-services) before moving on.
 
 ## What is Rate Limiting?
 
@@ -181,4 +181,4 @@ setting the rate limit to 5 times per minute.
 * If using Kong Manager, you enabled the Rate Limiting Advanced plugin,
 setting the rate limit to 5 times for every 30 seconds.
 
-Next, head on to learn about [proxy caching](/getting-started-guide/{{page.kong_version}}/improve-performance).
+Next, head on to learn about [proxy caching](/gateway/{{page.kong_version}}/get-started/comprehensive/improve-performance).

--- a/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
@@ -3,7 +3,7 @@ title: Secure your Services Using Authentication
 ---
 In this topic, you’ll learn about API Gateway authentication, set up the Key Authentication plugin, and add a consumer.  
 
-If you are following the getting started workflow, make sure you have completed [Improve Performance with Proxy Caching](/getting-started-guide/{{page.kong_version}}/improve-performance) before moving on.
+If you are following the getting started workflow, make sure you have completed [Improve Performance with Proxy Caching](/gateway/{{page.kong_version}}/get-started/comprehensive/improve-performance) before moving on.
 
 ## What is Authentication?
 
@@ -414,4 +414,4 @@ In this topic, you:
 * Created a new consumer named `consumer`.
 * Gave the consumer an API key of `apikey` so that it could access the `/mock` route with authentication.
 
-Next, you’ll learn about [load balancing upstream services using targets](/getting-started-guide/{{page.kong_version}}/load-balancing).
+Next, you’ll learn about [load balancing upstream services using targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing).

--- a/app/gateway/2.6.x/get-started/quickstart/adding-consumers.md
+++ b/app/gateway/2.6.x/get-started/quickstart/adding-consumers.md
@@ -2,23 +2,15 @@
 title: Adding Consumers
 ---
 
-<div class="alert alert-warning">
-  <strong>Before you start:</strong>
-  <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
-    <li>Make sure you've <a href="/gateway-oss/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
-    <li>Also, make sure you've <a href="/gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
-  </ol>
-</div>
-
 In the last section, we learned how to add plugins to Kong, in this section
 we're going to learn how to add consumers to your Kong instances. Consumers are
 associated to individuals using your Service, and can be used for tracking, access
 management, and more.
 
-**Note:** This section assumes you have [enabled][enabling-plugins] the
-[key-auth][key-auth] plugin. If you haven't, you can either [enable the
-plugin][enabling-plugins] or skip steps two and three.
+## Before you start
+* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
+* You have [configured a Service](/gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service)
+* You have [enabled the key-auth plugin](/gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins)
 
 ## 1. Create a Consumer through the RESTful API
 
@@ -87,11 +79,11 @@ Plugins, feel free to read more on Kong in one of the following documents:
 Questions? Issues? Contact us on one of the [Community Channels](/community)
 for help!
 
-[key-auth]: /plugins/key-authentication
-[API-consumers]: /gateway-oss/{{page.kong_version}}/admin-api#create-consumer
-[enabling-plugins]: /gateway-oss/{{page.kong_version}}/getting-started/enabling-plugins
-[configuration]: /gateway-oss/{{page.kong_version}}/configuration
-[CLI]: /gateway-oss/{{page.kong_version}}/cli
-[proxy]: /gateway-oss/{{page.kong_version}}/proxy
-[API]: /gateway-oss/{{page.kong_version}}/admin-api
-[cluster]: /gateway-oss/{{page.kong_version}}/clustering
+[key-auth]: /hub/kong-inc/key-auth
+[API-consumers]: /gateway/{{page.kong_version}}/admin-api#create-consumer
+[enabling-plugins]: /gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins
+[configuration]: /gateway/{{page.kong_version}}/reference/property-reference
+[CLI]: /gateway/{{page.kong_version}}/reference/cli
+[proxy]: /gateway/{{page.kong_version}}/reference/proxy
+[API]: /gateway/{{page.kong_version}}/admin-api
+[cluster]: /gateway/{{page.kong_version}}/reference/clustering

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-grpc-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-grpc-service.md
@@ -2,14 +2,6 @@
 title: Configuring a gRPC Service
 ---
 
-<div class="alert alert-warning">
-  <strong>Before you start:</strong>
-  <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
-    <li>Make sure you've <a href="/gateway-oss/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
-  </ol>
-</div>
-
 Note: this guide assumes familiarity with gRPC; for learning how to set up
 Kong with an upstream REST API, check out the [Configuring a Service guide][conf-service].
 
@@ -27,6 +19,9 @@ In Kong 1.3, gRPC support assumes gRPC over HTTP/2 framing. As such, make sure
 you have at least one HTTP/2 proxy listener (check out the [Configuration Reference][configuration-reference]
 for how to). In this guide, we will assume Kong is listening for HTTP/2 proxy
 requests on port 9080.
+
+## Before you start
+You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
 
 ## 1. Single gRPC Service and Route
 
@@ -277,12 +272,12 @@ tail -f grpc-say-hello.log
 {"latencies":{"request":3,"kong":1,"proxy":1},"service":{"host":"localhost","created_at":1564527408,"connect_timeout":60000,"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","protocol":"grpc","name":"grpc","read_timeout":60000,"port":15002,"updated_at":1564527408,"write_timeout":60000,"retries":5},"request":{"querystring":{},"size":"46","uri":"\/hello.HelloService\/SayHello","url":"http:\/\/localhost:9080\/hello.HelloService\/SayHello","headers":{"host":"localhost:9080","content-type":"application\/grpc","kong-debug":"1","user-agent":"grpc-go\/1.20.0-dev","te":"trailers"},"method":"POST"},"client_ip":"127.0.0.1","tries":[{"balancer_latency":0,"port":15002,"balancer_start":1564527733555,"ip":"127.0.0.1"}],"response":{"headers":{"kong-route-id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","content-type":"application\/grpc","connection":"close","kong-service-name":"grpc","kong-service-id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","kong-route-name":"say-hello","via":"kong\/1.2.1","x-kong-proxy-latency":"1","x-kong-upstream-latency":"1"},"status":200,"size":"298"},"route":{"id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","updated_at":1564527431,"protocols":["grpc"],"created_at":1564527431,"service":{"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c"},"name":"say-hello","preserve_host":false,"regex_priority":0,"strip_path":false,"paths":["\/hello.HelloService\/SayHello"],"https_redirect_status_code":426},"started_at":1564527733554}
 ```
 
-[enabling-plugins]: /gateway-oss/{{page.kong_version}}/getting-started/enabling-plugins
-[conf-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service
-[configuration-reference]: /gateway-oss/{{page.kong_version}}/configuration
+[enabling-plugins]: /gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins
+[conf-service]: /gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service
+[configuration-reference]: /gateway/{{page.kong_version}}/reference/property-reference/
 [grpc-reflection]: https://github.com/grpc/grpc/blob/master/doc/server_reflection_tutorial.md
 [grpcbin]: https://github.com/moul/grpcbin
 [grpcurl]: https://github.com/fullstorydev/grpcurl
 [protobuf]: https://raw.githubusercontent.com/moul/pb/master/hello/hello.proto
-[file-log]: /plugins/file-log
-[zipkin]: /plugins/zipkin
+[file-log]: /hub/kong-inc/file-log
+[zipkin]: /hub/kong-inc/zipkin

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
@@ -2,14 +2,6 @@
 title: Configuring a Service
 ---
 
-<div class="alert alert-warning">
-  <strong>Before you start:</strong>
-  <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
-    <li>Make sure you've <a href="/gateway-oss/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
-  </ol>
-</div>
-
 In this section, you'll be adding an API to Kong. In order to do this, you'll
 first need to add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
 it manages.
@@ -26,6 +18,9 @@ After configuring the Service and the Route, you'll be able to make requests thr
 
 Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, including adding Services and
 Routes, is made via requests on that API.
+
+## Before you start
+You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
 
 ## 1. Add your Service using the Admin API
 
@@ -131,7 +126,7 @@ Now that you've added your Service to Kong, let's learn how to enable plugins.
 
 Go to [Enabling Plugins &rsaquo;][enabling-plugins]
 
-[API]: /gateway-oss/{{page.kong_version}}/admin-api
-[enabling-plugins]: /gateway-oss/{{page.kong_version}}/getting-started/enabling-plugins
-[proxy-port]: /gateway-oss/{{page.kong_version}}/configuration/#nginx-section
+[API]: /gateway/{{page.kong_version}}/admin-api
+[enabling-plugins]: /gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins
+[proxy-port]: /gateway/{{page.kong_version}}/reference/property-reference/#nginx-section
 [mockbin]: https://mockbin.com/

--- a/app/gateway/2.6.x/get-started/quickstart/enabling-plugins.md
+++ b/app/gateway/2.6.x/get-started/quickstart/enabling-plugins.md
@@ -2,15 +2,6 @@
 title: Enabling Plugins
 ---
 
-<div class="alert alert-warning">
-  <strong>Before you start:</strong>
-  <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> - It should only take a minute!</li>
-    <li>Make sure you've <a href="/gateway-oss/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
-    <li>Also, make sure you've <a href="/gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
-  </ol>
-</div>
-
 In this section, you'll learn how to configure Kong plugins. One of the core
 principles of Kong is its extensibility through [plugins][plugins]. Plugins
 allow you to easily add new features to your Service or make it easier to
@@ -23,10 +14,13 @@ plugin, **only** requests with the correct key(s) will be proxied - all
 other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
+## Before you start
+* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run)
+* You have [configured your Service](/gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service) in {{site.base_gateway}}
 
 ## 1. Configure the key-auth plugin
 
-To configure the key-auth plugin for the Service you <a href="/gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service">configured in Kong</a>,
+To configure the key-auth plugin for the Service you <a href="/gateway/{{page.kong_version}}/getting-started/configuring-a-service">configured in Kong</a>,
 issue the following cURL request:
 
 ```bash
@@ -69,6 +63,6 @@ consumers to your Service so we can continue proxying requests through Kong.
 
 Go to [Adding Consumers &rsaquo;][adding-consumers]
 
-[key-auth]: /plugins/key-authentication
-[plugins]: /plugins
-[adding-consumers]: /gateway-oss/{{page.kong_version}}/getting-started/adding-consumers
+[key-auth]: /hub/kong-inc/key-auth
+[plugins]: /hub/
+[adding-consumers]: /gateway/{{page.kong_version}}/get-started/quickstart/adding-consumers

--- a/app/gateway/2.6.x/get-started/quickstart/index.md
+++ b/app/gateway/2.6.x/get-started/quickstart/index.md
@@ -7,7 +7,7 @@ API, where you'll manage entities including Services, Routes, and Consumers.
 
 ## Start Kong Gateway using Docker with a database
 
-One quick way to get Kong Gateway up and running is by using [Docker with a PostgreSQL database](https://docs.konghq.com/install/docker). We recommend this method to test out basic Kong Gateway functionality.
+One quick way to get Kong Gateway up and running is by using [Docker with a PostgreSQL database](/gateway/{{page.kong_version}}/install-and-run/docker). We recommend this method to test out basic Kong Gateway functionality.
 
 For a comprehensive list of installation options, see our [Kong Community Install page](https://konghq.com/install/#kong-community).
 
@@ -110,8 +110,8 @@ Now that you have Kong Gateway running, you can interact with the Admin API.
 
 To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
 
-[configuration-loading]: /gateway-oss/{{page.kong_version}}/configuration/#configuration-loading
-[CLI]: /gateway-oss/{{page.kong_version}}/cli
-[API]: /gateway-oss/{{page.kong_version}}/admin-api
-[datastore-section]: /gateway-oss/{{page.kong_version}}/configuration/#datastore-section
-[configuring-a-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service
+[configuration-loading]: /gateway/{{page.kong_version}}/reference/property-reference/#configuration-loading
+[CLI]: /gateway/{{page.kong_version}}/reference/cli
+[API]: /gateway/{{page.kong_version}}/admin-api
+[datastore-section]: /gateway/{{page.kong_version}}/reference/property-reference/#datastore-section
+[configuring-a-service]: /gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service

--- a/app/gateway/2.6.x/immunity/alerts.md
+++ b/app/gateway/2.6.x/immunity/alerts.md
@@ -1,21 +1,20 @@
 ---
 title: Immunity Alerts
+badge: enterprise
 ---
-
-### Introduction
 
 Immunity monitors all traffic that flows through Kong Enterprise. When an anomaly is detected, Immunity sends an alert to Kong Manager and displays on the Alerts dashboard. Alerts are built to signal the health of your microservices system and help pinpoint which endpoints are struggling.  
 
-### Alerts Dashboard
+## Alerts Dashboard
 Use the Alerts Dashboard in Kong Manager to view and manage alerts. When an alert is generated, it is automatically added to the Alerts Dashboard. The dashboard gives a high-level overview of identified alerts, including severity level, event type, status, and details about the alert. Click an alert to drill down into more details to further investigate the issue.
 
-### Types of Alerts
+## Types of Alerts
 Immunity evaluates your traffic every minute and creates an alert when it detects an anomalous event on either of two entity types: endpoint traffic or consumer traffic.
 
 * `Endpoint alerts` are generated from traffic belonging to one specific endpoint, for example, `GET www.testendpoint/start`.
 * `Consumer alerts` are generated from any traffic in a Workspace belonging to a registered Kong consumer. This traffic is identified by the consumer ID.
 
-#### Alert Events
+### Alert Events
 Dependent on the entity type, being an endpoint or consumer, Immunity creates an alert and identifies them as one of the following event types:
 * `value_type` alerts are triggered when incoming requests have a parameter value of a different type than is historically seen (such as Int instead of Str). Default severity level: Low.
 * `unknown_parameter` alerts are triggered when requests include parameters not seen before. Default severity level: Low.
@@ -24,7 +23,7 @@ Dependent on the entity type, being an endpoint or consumer, Immunity creates an
 * `latency_ms` alerts are triggered when incoming requests are significantly slower than historical records. Default severity level: High.
 * `statuscode` alerts are triggered when the proportion of 4XX or 5XX error codes is increasing, regardless of traffic volume. Default severity level: High.
 
-### Alert Severity Levels
+## Alert Severity Levels
 Alerts are classified with four severity levels:
 * **Low**: A low severity classification denotes the least important alerts. While you decide what a low severity means, we recommend that low severity indicates an alert that you want to review at a later time.
 * **Medium**: A medium severity classification denotes a mid-level important alert. This level is an alert level you will likely address within the sprint.
@@ -32,7 +31,7 @@ Alerts are classified with four severity levels:
 * **Ignored**: Alerts that are designated as ignored are not surfaced in the Kong Manager, Slack alerts, or /alerts endpoint.
 
 
-### Retrieving Generated Alerts
+## Retrieve Generated Alerts
 Monitor generated alerts using the following commands:
 
 ```bash
@@ -47,7 +46,7 @@ Or, access the alerts using a browser, using the ‘start and end’ values as p
 http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/alerts?start=2020-01-01 00:00:00&end=2020-01-02 00:00:00
 ```
 
-#### Alert Endpoint Parameters
+### Alert Endpoint Parameters
 The ‘/alerts’ endpoint uses the following parameters, which you can mix and match according to your monitoring needs:
 * `start and end`: Returns only alerts generated between the values in start and end parameters passed.
 * `alert_type`: Returns only alerts of the alert_type specified in the alert_type parameter. This parameter does not accept lists of alert types. The value passed must be one of [‘query_params’, ‘statuscode’, ‘latency_ms’, ‘traffic’]
@@ -59,10 +58,10 @@ The ‘/alerts’ endpoint uses the following parameters, which you can mix and 
 * `system_restored`: A true/false value indicates you only want returned alerts where the system_restored value is matching the boolean value passed into this parameter.
 * `severity`: One of "low", "medium", "high" which will restricts returned alerts of severities matching the value provided with this parameter.
 
-#### Alert Objects
+### Alert Objects
 Two types of data are returned by the ‘/alerts’ endpoint: a list of generated alerts and alerts metadata.
 
-##### List of Generated Alerts
+#### List of Generated Alerts
 The first is a list of the alerts generated, which are structured like this:
 * `id`: The alert_id of the alert.
 * `detected_at`: The time when the generated alert was detected. This time also correlates with the last time point in the data time series that generated this alert. For example, if the alert was generated on data from 1:00 pm to 1:01 pm, then the detected_at time corresponds with the most recent time point of 1:01 pm in the data used to make the alert.
@@ -73,13 +72,13 @@ The first is a list of the alerts generated, which are structured like this:
 * `system_restored`: This parameter takes True or False as a value, and returns notifications where the anomalous event’s system_restored status matches the value passed in the parameter.
 * `severity`: The severity level of this alert, values of [low, medium, high].
 
-##### Alert Metadata
+#### Alert Metadata
 The second type of data returned is alerts metadata which describes the overall count of alerts and breaks down counts by alert type, severity, system_restored, and filtered_total.
 
 
-### Configure Alert Severity
+## Configure Alert Severity
 
-#### Creating or Updating Alert Severity Rules
+### Create or Update Alert Severity Rules
 
 Depending on your system needs, you can adjust the severities of your alerts to varying degrees of specificity. You can configure alert severity on alert type, kong `route_id` or `service_id`, or any combination of the two.
 
@@ -126,7 +125,7 @@ When determining which severity to assign, Immunity will look for your configura
 
 When you hit the /alerts endpoint, for each alert, Immunity will first look for a rule specifying a severity for that route's kong `route_id` and `alert_name`. If it doesn't find a severity configuration, it moves down the list above until it returns the Immunity defaults for the alert's alert type.
 
-#### Removing Alert Severity Rule
+### Remove Alert Severity Rule
 
 You can remove alert-severity configuration rules by sending a delete request to /alerts/config. This endpoint takes these parameters:
 * `kong_entity`: The kong_entity of the rule you want deleted, or null for alert type rules.
@@ -146,7 +145,7 @@ curl -d '{"alert_name":null, "kong_entity":null}' \
  -X DELETE http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/alerts/config
 ```
 
-#### Viewing Alert Severity Configuration
+### View Alert Severity Configuration
 To view the rules you already have configured, enter a get request to /alerts/config to view all the rules:
 
 ```bash
@@ -178,7 +177,7 @@ A kong entity wide rule is the reverse with a json object that has a non-null `k
 {"alert_name": null, "kong_entity": "route-id-1", "severity": "low"}
 ```
 
-#### Reviewing High Value Information Alerts (HARS)
+### Review High Value Information Alerts (HARS)
 For value_type, unknown_parameter, and abnormal_value alerts, you can retrieve the HARS that created those alerts via the `http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/hars` endpoint. This endpoint accepts `alert_id` and/or `har_id` as parameters and returns HARS related to the parameters sent. You must specify one of these two parameters to receive HARS on the `http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/hars` endpoint.
 These are the parameters `http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/hars` accepts:
 

--- a/app/gateway/2.6.x/immunity/changelog.md
+++ b/app/gateway/2.6.x/immunity/changelog.md
@@ -1,5 +1,6 @@
 ---
 title: Kong Immunity Changelog
+badge: enterprise
 ---
 
 The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md](https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md).

--- a/app/gateway/2.6.x/immunity/index.md
+++ b/app/gateway/2.6.x/immunity/index.md
@@ -1,5 +1,6 @@
 ---
-title: Kong Immunity Overview
+title: Kong Immunity
+badge: enterprise
 ---
 
 **Kong Immunity** (Immunity) uses advanced machine learning to analyze traffic patterns in real-time to improve security, mitigate breaches and isolate issues.  
@@ -23,7 +24,7 @@ Traffic patterns provide a window into the behavior and performance of services 
 To identify potential issues, inefficiencies or performance bottlenecks, Immunity flags traffic that deviates from the expected or desired patterns without disrupting services. Depending on your needs and goals, you can adjust the settings of Immunity to recognize individual traffic events, patterns and other types of anomalous activity.
 
 ### Automatically Alert
-How quickly you respond to an event can mean the difference between a simple fix and a catastrophic outage. As Immunity detects anomalies in real time, it automatically sends a notification alerting you to the issue. Notifications are available via Slack and more. To avoid disruptions to your teams, you can designate specific users to receive alerts based on Role-Based Access Controls (RBAC) within [Kong Manager](/enterprise/latest/kong-manager/overview/).
+How quickly you respond to an event can mean the difference between a simple fix and a catastrophic outage. As Immunity detects anomalies in real time, it automatically sends a notification alerting you to the issue. Notifications are available via Slack and more. To avoid disruptions to your teams, you can designate specific users to receive alerts based on [Role-Based Access Controls (RBAC) within Kong Manager](/gateway/{{page.kong_version}}/configure/auth/rbac).
 
 ### Analyze and Address Anomalies
-To help effectively remedy issues in your services, Immunity allows you to review anomalies to understand the root cause and take action. In conjunction with [Kong Vitals](/enterprise/latest/vitals/overview/), you can fully understand a service's anomalous behavior and address the issue with just a few clicks. As the usage of Immunity increases, it learns your baseline behavior and continuously refines its model to better detect or ignore anomalies.
+To help effectively remedy issues in your services, Immunity allows you to review anomalies to understand the root cause and take action. In conjunction with [Kong Vitals](/gateway/{{page.kong_version}}/vitals/), you can fully understand a service's anomalous behavior and address the issue with just a few clicks. As the usage of Immunity increases, it learns your baseline behavior and continuously refines its model to better detect or ignore anomalies.

--- a/app/gateway/2.6.x/immunity/install-configure.md
+++ b/app/gateway/2.6.x/immunity/install-configure.md
@@ -1,8 +1,8 @@
 ---
 title: Kong Immunity Installation and Configuration
+badge: enterprise
 ---
 
-## Introduction
 Kong Immunity (Immunity) is installed on Kong Enterprise, either on Kubernetes or Docker, as defined below. Immunity uses the Collector App and Collector Plugin to communicate with Kong Enterprise.
 
 {% include /md/enterprise/download/immunity.md version='>2.1' %}
@@ -158,6 +158,6 @@ Substitute `default` for your own workspace name.
 {% endnavtabs %}
 
 ## Summary
-The Collector App is installed and the Collector Plugin is enabled on Kong Enterprise. You are now ready to analyze incoming traffic for [alerts](/enterprise/{{page.kong_version}}/immunity/alerts).
+The Collector App is installed and the Collector Plugin is enabled on Kong Enterprise. You are now ready to analyze incoming traffic for [alerts](/gateway/{{page.kong_version}}/immunity/alerts).
 
-For any issues encountered when setting up Collector App, Collector Plugin, or configuring other aspects of Immunity, see [troubleshooting](/enterprise/{{page.kong_version}}/immunity/troubleshooting) for help debugging common problems.
+For any issues encountered when setting up Collector App, Collector Plugin, or configuring other aspects of Immunity, see [troubleshooting](/gateway/{{page.kong_version}}/immunity/troubleshooting) for help debugging common problems.

--- a/app/gateway/2.6.x/immunity/model-training.md
+++ b/app/gateway/2.6.x/immunity/model-training.md
@@ -1,8 +1,7 @@
 ---
 title: Immunity Model Training
+badge: enterprise
 ---
-
-## Introduction
 
 Immunity automatically starts training its models once it is up and running and receiving data. Immunity creates a model for every unique endpoint + method combination it sees in incoming traffic. For example, if you have an endpoint [www.test-website.com/buy](http://www.test-website.com/buy) and traffic comes in with both GET and POST requests for that endpoint, Immunity will create two models: one for the endpoint + GET traffic and one for the endpoint + POST traffic.
 

--- a/app/gateway/2.6.x/immunity/slack-integration.md
+++ b/app/gateway/2.6.x/immunity/slack-integration.md
@@ -1,5 +1,6 @@
 ---
 title: Alert Slack Integration
+badge: enterprise
 ---
 
 Immunity can send Slack notifications for unusual traffic, using a Slack webhook to post messages to a Slack workspace. To obtain a webhook URL, use the steps in this topic.

--- a/app/gateway/2.6.x/immunity/troubleshooting.md
+++ b/app/gateway/2.6.x/immunity/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Common Issues
+badge: enterprise
 ---
 
 This troubleshooting topic contains common issues you might experience when using Kong Immunity, and troubleshooting tips for resolving these issues. Information is also provided about how to contact Kong to report an issue, and how to submit suggestions to help improve functionality.
@@ -62,7 +63,7 @@ If you cannot make successful requests to Kong Admin with `{KONG_PROTOCOL}://{KO
 
 ### I'm not seeing any alerts, even though the Collector App is connected to Kong and is receiving traffic
 
-Immunity waits at least an hour before it makes its first models. If the Collector App has not been up for very long, then the anomaly detection models used to generate alerts have not been created. These models are created using cURL. See [Immunity Model Training](/enterprise/{{page.kong_version}}/immunity/model-training) for more information.
+Immunity waits at least an hour before it makes its first models. If the Collector App has not been up for very long, then the anomaly detection models used to generate alerts have not been created. These models are created using cURL. See [Immunity Model Training](/gateway/{{page.kong_version}}/immunity/model-training) for more information.
 
 
 ### I triggered model training and I'm still not seeing alerts

--- a/app/gateway/2.6.x/index.md
+++ b/app/gateway/2.6.x/index.md
@@ -8,7 +8,7 @@ gateway. An API gateway is a reverse proxy that lets you manage, configure, and 
 requests to your APIs.
 
 {{site.base_gateway}} runs in front of any RESTful API and can be extended through
-modules and plugins. It's designed to run on decentralized architectures, including 
+modules and plugins. It's designed to run on decentralized architectures, including
 hybrid-cloud and multi-cloud deployments.
 
 With {{site.base_gateway}}, users can:

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -295,8 +295,8 @@ setup, reach out to your support contact or head over to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/{{page.kong_version}}/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the
-[`/licenses` Admin API endpoint](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+[`/licenses` Admin API endpoint](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license).

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -282,8 +282,8 @@ The steps involved in starting Kong in [DB-less mode] are the following:
     curl -i http://localhost:8001/services
     ```
 
-[DB-less mode]: /gateway-oss/latest/db-less-and-declarative-config/
-[Declarative Configuration Format]: /gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format
+[DB-less mode]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/
+[Declarative Configuration Format]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/#the-declarative-configuration-format
 [Docker Volume]: https://docs.docker.com/storage/volumes/
 
 ## Troubleshooting

--- a/app/gateway/2.6.x/install-and-run/migrate-ce-to-ke.md
+++ b/app/gateway/2.6.x/install-and-run/migrate-ce-to-ke.md
@@ -12,7 +12,7 @@ performs that migration command on your behalf.
 > **Important:** You can only migrate to a {{site.ee_product_name}} version that
 supports the same {{site.ce_product_name}} version.
 
-### Prerequisites
+## Prerequisites
 
 {:.warning}
 > **Warning:** This action is irreversible, therefore it is strongly
@@ -20,10 +20,10 @@ supports the same {{site.ce_product_name}} version.
    {{site.ce_product_name}} to {{site.ee_product_name}}.
 
 * If running a version of {{site.ce_product_name}} earlier than 2.6.x,
-  [upgrade to Kong 2.6.x](/gateway-oss/2.6.x/upgrading/) before migrating
+  [upgrade to Kong 2.6.x](/gateway/{{page.kong_version}}/upgrade-oss/) before migrating
   {{site.ce_product_name}} to {{site.ee_product_name}} 2.6.x.
 
-#### Migration steps
+## Migration steps
 
 The following steps guide you through the migration process.
 

--- a/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
@@ -11,7 +11,7 @@ Upgrade to major, minor, and patch {{site.ee_product_name}} releases using the
 
 You can also use the commands to migrate all {{site.ce_product_name}} entities
 to {{site.ee_product_name}}. See
-[Migrating from Kong Gateway to Kong Enterprise](/enterprise/{{page.kong_version}}/deployment/upgrades/migrate-ce-to-ke/).
+[Migrating from Kong Gateway to Kong Enterprise](/gateway/{{page.kong_version}}/install-and-run/migrate-ce-to-ke/).
 
 If you experience any issues when running migrations, contact
 [Kong Support](https://support.konghq.com/support/s/) for assistance.
@@ -19,8 +19,8 @@ If you experience any issues when running migrations, contact
 ## Upgrade path for Kong Gateway releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
-distinction between major, minor, and patch versions. The upgrade 
-path for major and minor versions differs depending on the previous version 
+distinction between major, minor, and patch versions. The upgrade
+path for major and minor versions differs depending on the previous version
 from which you are migrating:
 
 - Upgrading from 2.5.x to 2.6.x is a minor upgrade; however, read below for important
@@ -69,12 +69,12 @@ affect your current installation.
 ### Hybrid mode considerations
 
 {:.important}
-> **Important:** If you are currently running in [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
+> **Important:** If you are currently running in [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/),
 upgrade the Control Plane first, and then the Data Planes.
 
 * If you are currently running 2.6.x in classic (traditional)
   mode and want to run in hybrid mode instead, follow the hybrid mode
-  [installation instructions](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)
+  [installation instructions](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode-setup/)
   after running the migration.
 * Custom plugins (either your own plugins or third-party plugins that are not shipped with Kong)
   need to be installed on both the Control Plane and the Data Planes in Hybrid mode. Install the
@@ -84,30 +84,30 @@ upgrade the Control Plane first, and then the Data Planes.
 
 ### Kong for Kubernetes considerations
 
-The Helm chart automates the upgrade migration process. When running `helm upgrade`, 
-the chart spawns an initial job to run `kong migrations up` and then spawns new 
-Kong pods with the updated version. Once these pods become ready, they begin processing 
-traffic and old pods are terminated. Once this is complete, the chart spawns another job 
+The Helm chart automates the upgrade migration process. When running `helm upgrade`,
+the chart spawns an initial job to run `kong migrations up` and then spawns new
+Kong pods with the updated version. Once these pods become ready, they begin processing
+traffic and old pods are terminated. Once this is complete, the chart spawns another job
 to run `kong migrations finish`.
 
-While the migrations themselves are automated, the chart does not automatically ensure 
-that you follow the recommended upgrade path. If you are upgrading from more than one minor 
+While the migrations themselves are automated, the chart does not automatically ensure
+that you follow the recommended upgrade path. If you are upgrading from more than one minor
 Kong version back, check the upgrade path recommendations for Kong open source or Kong Gateway.
 
-Although not required, users should upgrade their chart version and Kong version independently. 
-In the event of any issues, this will help clarify whether the issue stems from changes in 
+Although not required, users should upgrade their chart version and Kong version independently.
+In the event of any issues, this will help clarify whether the issue stems from changes in
 Kubernetes resources or changes in Kong.
 
-For specific Kong for Kubernetes version upgrade considerations, see 
+For specific Kong for Kubernetes version upgrade considerations, see
 [Upgrade considerations](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
 
 #### Kong deployment split across multiple releases
 
-The standard chart upgrade automation process assumes that there is only a single Kong release 
-in the Kong cluster, and runs both `migrations up` and `migrations finish` jobs. 
+The standard chart upgrade automation process assumes that there is only a single Kong release
+in the Kong cluster, and runs both `migrations up` and `migrations finish` jobs.
 
-If you split your Kong deployment across multiple Helm releases (to create proxy-only 
-and admin-only nodes, for example), you must set which migration jobs run based on your 
+If you split your Kong deployment across multiple Helm releases (to create proxy-only
+and admin-only nodes, for example), you must set which migration jobs run based on your
 upgrade order.
 
 To handle clusters split across multiple releases, you should:
@@ -126,7 +126,7 @@ To handle clusters split across multiple releases, you should:
    --set migrations.preUpgrade=false \
    --set migrations.postUpgrade=false
    ```
-3. Upgrade the final release with: 
+3. Upgrade the final release with:
 
    ```shell
    helm upgrade RELEASENAME -f values.yaml \

--- a/app/gateway/2.6.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-oss.md
@@ -41,7 +41,7 @@ repository contains [openresty-build-tools](https://github.com/Kong/kong-build-t
 which allows you to more easily build OpenResty with the necessary patches and modules.
 
 There is a new way to deploy Go using Plugin Servers.
-For more information, see [Developing Go plugins](https://docs.konghq.com/gateway-oss/2.6.x/external-plugins/#developing-go-plugins).
+For more information, see [Developing Go plugins](/gateway/{{page.kong_version}}/reference/external-plugins/#developing-go-plugins).
 
 ### Template changes
 

--- a/app/gateway/2.6.x/plan-and-deploy/default-ports.md
+++ b/app/gateway/2.6.x/plan-and-deploy/default-ports.md
@@ -1,23 +1,22 @@
 ---
 title: Default Ports
-toc: false
 ---
 By default, {{site.base_gateway}} listens on the following ports:
 
 | Port                                                                               | Protocol | Description | Gateway tier |
 |:-----------------------------------------------------------------------------------|:---------|:------------|:----------------------|
-| [`:8000`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)      | HTTP     | Takes incoming HTTP traffic from **Consumers**, and forwards it to upstream  **Services**. | All tiers and modes |
-| [`:8443`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from **Consumers**, and forwards it to upstream **Services**. | All tiers and modes |
-| [`:8001`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
-| [`:8444`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
-| [`:8005`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
-| [`:8006`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | All tiers and modes |
-| [`:8002`](/enterprise/{{page.kong_version}}/property-reference/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |
-| [`:8445`](/enterprise/{{page.kong_version}}/property-reference/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | {{site.base_gateway}} free mode |
-| [`:8003`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
-| [`:8446`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**.  | {{site.base_gateway}} Enterprise tier |
-| [`:8004`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
-| [`:8447`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
+| [`:8000`](/gateway/{{page.kong_version}}/reference/property-reference/#proxy_listen)      | HTTP     | Takes incoming HTTP traffic from **Consumers**, and forwards it to upstream  **Services**. | All tiers and modes |
+| [`:8443`](/gateway/{{page.kong_version}}/reference/property-reference/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from **Consumers**, and forwards it to upstream **Services**. | All tiers and modes |
+| [`:8001`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
+| [`:8444`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
+| [`:8005`](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
+| [`:8006`](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | All tiers and modes |
+| [`:8002`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |
+| [`:8445`](/gateway/{{page.kong_version}}/reference/property-reference/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | {{site.base_gateway}} free mode |
+| [`:8003`](/gateway/{{page.kong_version}}/reference/property-reference/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
+| [`:8446`](/gateway/{{page.kong_version}}/reference/property-reference/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**.  | {{site.base_gateway}} Enterprise tier |
+| [`:8004`](/gateway/{{page.kong_version}}/reference/property-reference/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
+| [`:8447`](/gateway/{{page.kong_version}}/reference/property-reference/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |
 
 {:.note}
 > **Note:** Kong Gateway free mode and Enterprise tier are not available for

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -5,7 +5,7 @@ title: Deploy Kong Gateway in Hybrid Mode
 ## Prerequisites
 To get started with a Hybrid mode deployment, first install an instance of
 {{site.base_gateway}} with TLS to be your Control Plane (CP) node. See the
-[installation documentation](/enterprise/{{page.kong_version}}/deployment/installation/overview)
+[installation documentation](/gateway/{{page.kong_version}}/install-and-run/)
 for details.
 
 We will bring up any subsequent Data Plane (DP) instances in this topic.
@@ -356,7 +356,7 @@ is disabled.
 
 In addition, the certificate from `cluster_cert` (in `shared` mode) or `cluster_ca_cert`
 (in `pki` mode) is automatically added to the trusted chain in
-[`lua_ssl_trusted_certificate`](/enterprise/{{page.kong_version}}/property-reference/#lua_ssl_trusted_certificate).
+[`lua_ssl_trusted_certificate`](/gateway/{{page.kong_version}}/reference/property-reference/#lua_ssl_trusted_certificate).
 
 {:.important}
 > **Important:** Data Plane nodes receive updates from the Control Plane via a format
@@ -369,10 +369,10 @@ on how data plane nodes process configuration.
 
 {% navtabs %}
 {% navtab Using Docker %}
-1. Using the [Docker installation documentation](/enterprise/{{page.kong_version}}/deployment/installation/docker),
+1. Using the [Docker installation documentation](/gateway/{{page.kong_version}}/install-and-run/docker),
 follow the instructions to:
-    1. [Download {{site.base_gateway}}](/enterprise/{{page.kong_version}}/deployment/installation/docker#pull-image).
-    2. [Create a Docker network](/enterprise/{{page.kong_version}}/deployment/installation/docker/#create-network).
+    1. [Download {{site.base_gateway}}](/gateway/{{page.kong_version}}/install-and-run/docker#pull-image).
+    2. [Create a Docker network](/gateway/{{page.kong_version}}/install-and-run/docker/#create-network).
 
     {:.warning}
     > **Warning:** Do not start or create a database on this node.
@@ -445,7 +445,7 @@ follow the instructions to:
 {% endnavtab %}
 {% navtab Using kong.conf %}
 
-1. Find the documentation for [your platform](/enterprise/{{page.kong_version}}/deployment/installation),
+1. Find the documentation for [your platform](/gateway/{{page.kong_version}}/install-and-run),
 and follow the instructions in Steps 1 and 2 **only** to download
 {{site.base_gateway}} and install Kong.
 
@@ -587,22 +587,22 @@ in Hybrid mode.
 
 Parameter | Description | CP or DP {:width=10%:}
 --------- | ----------- | ----------------------
-[`role`](/enterprise/{{page.kong_version}}/property-reference/#role) <br>*Required* | Determines whether the {{site.base_gateway}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
-[`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`proxy_listen`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
-[`cluster_control_plane`](/enterprise/{{page.kong_version}}/property-reference/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
-[`cluster_mtls`](/enterprise/{{page.kong_version}}/property-reference/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
+[`role`](/gateway/{{page.kong_version}}/reference/property-reference/#role) <br>*Required* | Determines whether the {{site.base_gateway}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
+[`cluster_listen`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`proxy_listen`](/gateway/{{page.kong_version}}/reference/property-reference/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
+[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+[`cluster_control_plane`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
+[`cluster_mtls`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 
 The following properties are used differently between `shared` and `pki` modes:
 
 Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 --------- | ----------- | ------------------------- | ----------------------
-[`cluster_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert) and [`cluster_cert_key`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
-[`cluster_ca_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
-[`cluster_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_cert`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_cert) and [`cluster_cert_key`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
+[`cluster_ca_cert`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
+[`cluster_server_name`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
+[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/property-reference/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next steps
 

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/index.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/index.md
@@ -2,7 +2,6 @@
 title: Hybrid Mode Overview
 ---
 
-## Introduction
 Traditionally, Kong has always required a database, which could be either
 Postgres or Cassandra, to store configured entities such as Routes, Services,
 and Plugins.
@@ -50,10 +49,10 @@ control and monitor the status of the entire Kong cluster.
 ## Platform Compatibility
 
 You can run {{site.base_gateway}} in Hybrid mode on any platform where
-{{site.base_gateway}} is [supported](/enterprise/{{page.kong_version}}/deployment/installation/overview).
+{{site.base_gateway}} is [supported](/gateway/{{page.kong_version}}/install-and-run/).
 
 ### Kubernetes Support and Additional Documentation
-[Kong Enterprise on Kubernetes](/enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes)
+[Kong Enterprise on Kubernetes](/gateway/{{page.kong_version}}/install-and-run/kubernetes)
 fully supports Hybrid mode deployments, with or without the Kong Ingress Controller.
 
 For the full Kubernetes Hybrid mode documentation, see
@@ -204,13 +203,13 @@ multiple Control Planes and redirecting the traffic using a TCP proxy.
 
 ## Readonly Status API endpoints on Data Plane
 
-Several readonly endpoints from the [Admin API](/enterprise/{{page.kong_version}}/admin-api)
-are exposed to the [Status API](/enterprise/{{page.kong_version}}/property-reference/#status_listen) on data planes, including the following:
+Several readonly endpoints from the [Admin API](/gateway/{{page.kong_version}}/admin-api)
+are exposed to the [Status API](/gateway/{{page.kong_version}}/reference/property-reference/#status_listen) on data planes, including the following:
 
 - GET /upstreams/{upstream}/targets/
-- [GET /upstreams/{upstream}/health/](/enterprise/{{page.kong_version}}/admin-api/#show-upstream-health-for-node)
-- [GET /upstreams/{upstream}/targets/all/](/enterprise/{{page.kong_version}}/admin-api/#list-all-targets)
+- [GET /upstreams/{upstream}/health/](/gateway/{{page.kong_version}}/admin-api/#show-upstream-health-for-node)
+- [GET /upstreams/{upstream}/targets/all/](/gateway/{{page.kong_version}}/admin-api/#list-all-targets)
 - GET /upstreams/{upstream}/targets/{target}
 
-Please refer to [Upstream objects](/enterprise/{{page.kong_version}}/admin-api/#upstream-object) in the Admin API documentation for more information about the
+Please refer to [Upstream objects](/gateway/{{page.kong_version}}/admin-api/#upstream-object) in the Admin API documentation for more information about the
 endpoints.

--- a/app/gateway/2.6.x/plan-and-deploy/kong-user.md
+++ b/app/gateway/2.6.x/plan-and-deploy/kong-user.md
@@ -5,7 +5,7 @@ title: Running Kong as a Non-Root User
 After installing {{site.ee_product_name}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user instead of the `root` user.
 This makes the Nginx master and worker processes use the built-in `kong` user and group credentials, overriding any settings in the
-[`nginx_user`](/enterprise/{{page.kong_version}}/property-reference/#nginx_user)
+[`nginx_user`](/gateway/{{page.kong_version}}/reference/property-reference/#nginx_user)
 configuration property. It is also possible to run Kong as a custom non-root user.
 
 {:.important}
@@ -22,11 +22,10 @@ privileged system calls in the operating system.
 ## Prerequisites
 
 {{site.ee_product_name}} is installed on one of the following Linux distributions:
-* [Amazon Linux](/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux)
-* [Amazon Linux 2](/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux-2)
-* [CentOS](/enterprise/{{page.kong_version}}/deployment/installation/centos)
-* [RHEL](/enterprise/{{page.kong_version}}/deployment/installation/rhel)
-* [Ubuntu](/enterprise/{{page.kong_version}}/deployment/installation/ubuntu)
+* [Amazon Linux 1 or 2](/gateway/{{page.kong_version}}/install-and-run/amazon-linux)
+* [CentOS](/gateway/{{page.kong_version}}/install-and-run/centos)
+* [RHEL](/gateway/{{page.kong_version}}/install-and-run/rhel)
+* [Ubuntu](/gateway/{{page.kong_version}}/install-and-run/ubuntu)
 
 ## Run {{site.ee_product_name}} as the built-in kong user
 

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/access-license.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/access-license.md
@@ -1,6 +1,5 @@
 ---
 title: Access Your Kong Gateway License
-toc: false
 badge: enterprise
 ---
 
@@ -12,12 +11,12 @@ You will receive this file from Kong when you sign up for a
 
 <div class="alert alert-ee blue">
 <b>Note:</b> The free mode does not require a license. See
-<a href="/enterprise/{{page.kong_version}}/deployment/licensing">Kong Gateway Licensing</a>
+<a href="/gateway/{{page.kong_version}}/plan-and-deploy/licenses">Kong Gateway Licensing</a>
 for a feature comparison.
 </div>
 
 Once a license has been deployed to a {{site.base_gateway}} node, retrieve it
-using the [`/licenses` Admin API endpoint](/enterprise/{{page.kong_version}}/admin-api/licenses/examples).
+using the [`/licenses` Admin API endpoint](/gateway/{{page.kong_version}}/admin-api/licenses/examples).
 
 If you have purchased a subscription but haven't received a license file,
 contact your sales representative.

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/deploy-license.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/deploy-license.md
@@ -4,6 +4,6 @@ badge: enterprise
 ---
 
 Deploy an enterprise license to a {{site.base_gateway}} installation to gain access
-to [Enterprise-specific features](/enterprise/{{page.kong_version}}/deployment/licensing).
+to [Enterprise-specific features](/gateway/{{page.kong_version}}/licenses).
 
 {% include /md/enterprise/deploy-license.md heading="##" kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/index.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/index.md
@@ -3,8 +3,6 @@ title: Kong Gateway Licensing
 badge: enterprise
 ---
 
-## Overview
-
 {{site.base_gateway}} can be used with or without a license. For Enterprise
 functionality, {{site.base_gateway}} enforces the presence and validity of a
 {{site.konnect_product_name}} license file.
@@ -45,7 +43,7 @@ of any `kong` CLI commands. License file environmental variables must be
 exported to the shell in which the Nginx process will run, ahead of the `kong`
 CLI tool.
 
-For more information, see [Deploy Your License](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+For more information, see [Deploy Your License](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license).
 
 ## Examining the license data on a Kong Gateway node
 Retrieve license data using the Admin API's `/licenses` endpoint, or through

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/report.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/report.md
@@ -2,8 +2,6 @@
 title: Monitor License Usage
 badge: enterprise
 ---
-
-## Overview
 Obtain information about your {{site.ee_gateway_name}} deployment, including license usage and deployment information using the **License Report** module. Share this information with Kong to perform a health-check analysis of product utilization and overall deployment performance to ensure your organization is optimized with the best license and deployment plan for your needs.
 
 How the license report module works:

--- a/app/gateway/2.6.x/plan-and-deploy/security/start-kong-securely.md
+++ b/app/gateway/2.6.x/plan-and-deploy/security/start-kong-securely.md
@@ -15,7 +15,7 @@ following the guide below. It may only be added once.
 
 ## Prerequisites
 
-After [installing Kong Enterprise](/enterprise/{{page.kong_version}}/deployment/installation/overview/),
+After [installing Kong Enterprise](/gateway/{{page.kong_version}}/install-and-run//),
 either modify the configuration file or set environment variables for
 the following properties:
 
@@ -26,7 +26,7 @@ must have adequate **Permissions** in order for the request to succeed.
 * If using Kong Manager, select the type of authentication that **Admins**
 should use to log in. For the purpose of this guide, `admin_gui_auth`
 may be set to `basic-auth`. See
-[Securing Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/security) for other types
+[Securing Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/) for other types
 of authentication.
 
 For a simple configuration to use for the subsequent Getting
@@ -43,7 +43,7 @@ admin_listen = 0.0.0.0:8001, 0.0.0.0:8444 ssl
 * Under all circumstances, the `secret` must be manually set to a string.
 * If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
-Learn more about these properties in [Session Security in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#session-security), and see [example configurations](/enterprise/{{page.kong_version}}/kong-manager/authentication/sessions/#example-configurations).
+Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/configure/auth/kong-manager/sessions/#example-configurations).
 
 ## Step 1
 
@@ -60,11 +60,11 @@ used as a `Kong-Admin-Token` to make Admin API requests.
 
 **Note:** only one **Super Admin** may be created using this method, and only
 on a fresh installation with an empty database. If one is not created during migrations,
-follow [this guide](/enterprise/{{page.kong_version}}/kong-manager/authentication/super-admin/#how-to-create-your-first-super-admin-account-post-installation) to remediate.
+follow [this guide](/gateway/{{page.kong_version}}/configure/auth/rbac/add-admin/) to remediate.
 
 Future migrations will not update the password or create additional **Super Admins**.
 To add additional **Super Admins** it is necessary to
-[invite a new user as a **Super Admin** in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/admins/invite/#how-to-invite-a-new-admin-from-the-organization-page).
+[invite a new user as a **Super Admin** in Kong Manager](/gateway/{{page.kong_version}}/configure/auth/kong-manager/super-admin/).
 
 ## Step 2
 
@@ -83,7 +83,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to [your own configuration](/1.0.x/configuration/#configuration-loading).
+allowing you to point to [your own configuration](/gateway/{{page.kong_version}}/reference/property-reference/#configuration-loading).
 
 ## Step 4
 

--- a/app/gateway/2.6.x/plan-and-deploy/systemd.md
+++ b/app/gateway/2.6.x/plan-and-deploy/systemd.md
@@ -4,7 +4,7 @@ title: Control Kong Gateway through systemd
 
 ### Introduction
 
-This document includes instructions on how to integrate Kong Enterprise with systemd for Debian and RPM based packages. Note that some of the supported GNU/Linux distributions for Kong Enterprise may not have adopted systemd as their default init system (for example, CentOS 6 and RHEL 6). For the following instructions, it is assumed that Kong Enterprise has already been [installed and configured](https://docs.konghq.com/enterprise/latest/deployment/installation/overview/) on a systemd-supported GNU/Linux distribution.
+This document includes instructions on how to integrate Kong Enterprise with systemd for Debian and RPM based packages. Note that some of the supported GNU/Linux distributions for Kong Enterprise may not have adopted systemd as their default init system (for example, CentOS 6 and RHEL 6). For the following instructions, it is assumed that Kong Enterprise has already been [installed and configured](/gateway/{{page.kong_version}}/install-and-run) on a systemd-supported GNU/Linux distribution.
 
 ## Start Kong Enterprise
 
@@ -81,25 +81,25 @@ To view the journald logs:
 To view the syslog logs:
    `tail -F /var/log/syslog`
 
-### Customize Kong's Nginx instance [using the Nginx directive injection system](https://docs.konghq.com/latest/configuration/#injecting-individual-nginx-directives)
+### Customize Kong's Nginx instance using the Nginx directive injection system
 
-To use the injection system, add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred. Note the quoting rules defined by systemd to specify an environment variable containing spaces:
+To use the [injection system](/gateway/{{site.kong_version}}/reference/property-reference/#injecting-individual-nginx-directives), add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred. Note the quoting rules defined by systemd to specify an environment variable containing spaces:
 
 ```
 Environment="KONG_NGINX_HTTP_OUTPUT_BUFFERS=4 64k"
 ```
 
-### Customize Kong's Nginx instance [using `--nginx-conf`](https://docs.konghq.com/latest/configuration/#custom-nginx-templates)
+### Customize Kong's Nginx instance using `--nginx-conf`
 
-To use the `--nginx-conf` argument, modify the `ExecStartPre` systemd directive to execute `kong prepare` with the `--nginx-conf` argument. For example, if you have a custom template at `/usr/local/kong/custom-nginx.template`, modify the `ExecStartPre` directive as follows:
+To use the [`--nginx-conf`](/gateway/{{site.kong_version}}/reference/property-reference/#custom-nginx-templates) argument, modify the `ExecStartPre` systemd directive to execute `kong prepare` with the `--nginx-conf` argument. For example, if you have a custom template at `/usr/local/kong/custom-nginx.template`, modify the `ExecStartPre` directive as follows:
 
 ```
 ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong --nginx-conf /usr/local/kong/custom-nginx.template
 ```
 
-### Customize Kong's Nginx instance [including files via the injected Nginx directives](https://docs.konghq.com/1.0.x/configuration/#including-files-via-injected-nginx-directives)
+### Customize Kong's Nginx instance including files via the injected Nginx directives
 
-To include files via the injected Nginx directives, add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred:
+To [include files via the injected Nginx directives](/gateway/{{site.kong_version}}/reference/property-reference/#including-files-via-injected-nginx-directives), add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred:
 
 ```
 Environment=KONG_NGINX_HTTP_INCLUDE=/path/to/your/my-server.kong.conf

--- a/app/gateway/2.6.x/plan-and-deploy/systemd.md
+++ b/app/gateway/2.6.x/plan-and-deploy/systemd.md
@@ -83,7 +83,7 @@ To view the syslog logs:
 
 ### Customize Kong's Nginx instance using the Nginx directive injection system
 
-To use the [injection system](/gateway/{{site.kong_version}}/reference/property-reference/#injecting-individual-nginx-directives), add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred. Note the quoting rules defined by systemd to specify an environment variable containing spaces:
+To use the [injection system](/gateway/{{page.kong_version}}/reference/property-reference/#injecting-individual-nginx-directives), add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred. Note the quoting rules defined by systemd to specify an environment variable containing spaces:
 
 ```
 Environment="KONG_NGINX_HTTP_OUTPUT_BUFFERS=4 64k"
@@ -91,7 +91,7 @@ Environment="KONG_NGINX_HTTP_OUTPUT_BUFFERS=4 64k"
 
 ### Customize Kong's Nginx instance using `--nginx-conf`
 
-To use the [`--nginx-conf`](/gateway/{{site.kong_version}}/reference/property-reference/#custom-nginx-templates) argument, modify the `ExecStartPre` systemd directive to execute `kong prepare` with the `--nginx-conf` argument. For example, if you have a custom template at `/usr/local/kong/custom-nginx.template`, modify the `ExecStartPre` directive as follows:
+To use the [`--nginx-conf`](/gateway/{{page.kong_version}}/reference/property-reference/#custom-nginx-templates) argument, modify the `ExecStartPre` systemd directive to execute `kong prepare` with the `--nginx-conf` argument. For example, if you have a custom template at `/usr/local/kong/custom-nginx.template`, modify the `ExecStartPre` directive as follows:
 
 ```
 ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong --nginx-conf /usr/local/kong/custom-nginx.template
@@ -99,7 +99,7 @@ ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong --nginx-conf /usr/lo
 
 ### Customize Kong's Nginx instance including files via the injected Nginx directives
 
-To [include files via the injected Nginx directives](/gateway/{{site.kong_version}}/reference/property-reference/#including-files-via-injected-nginx-directives), add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred:
+To [include files via the injected Nginx directives](/gateway/{{page.kong_version}}/reference/property-reference/#including-files-via-injected-nginx-directives), add the below `Environment` systemd directive to your custom service at `/etc/systemd/system/kong-enterprise-edition.service` if environment variables are preferred:
 
 ```
 Environment=KONG_NGINX_HTTP_INCLUDE=/path/to/your/my-server.kong.conf

--- a/app/gateway/2.6.x/plugin-development/access-the-datastore.md
+++ b/app/gateway/2.6.x/plugin-development/access-the-datastore.md
@@ -72,4 +72,4 @@ For a real-life example of the DAO being used in a plugin, see the
 
 Next: [Storing Custom Entities &rsaquo;]({{page.book.next}})
 
-[Plugin Development Kit]: /gateway-oss/{{page.kong_version}}/pdk
+[Plugin Development Kit]: /gateway/{{page.kong_version}}/pdk

--- a/app/gateway/2.6.x/plugin-development/admin-api.md
+++ b/app/gateway/2.6.x/plugin-development/admin-api.md
@@ -11,7 +11,7 @@ chapter: 8
 
 <div class="alert alert-warning">
   <strong>Note:</strong> The Admin API extensions are available only
-  for HTTP plugins, not Stream plugins. 
+  for HTTP plugins, not Stream plugins.
 </div>
 
 ## Introduction
@@ -176,4 +176,4 @@ three functions:
 
 Next: [Write tests for your plugin]({{page.book.next}})
 
-[Admin API]: /gateway-oss/{{page.kong_version}}/admin-api/
+[Admin API]: /gateway/{{page.kong_version}}/admin-api/

--- a/app/gateway/2.6.x/plugin-development/custom-entities.md
+++ b/app/gateway/2.6.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -676,5 +676,5 @@ when they change in the datastore: [Caching custom entities]({{page.book.next}})
 
 Next: [Caching custom entities &rsaquo;]({{page.book.next}})
 
-[Admin API]: /gateway-oss/{{page.kong_version}}/admin-api/
-[Plugin Development Kit]: /gateway-oss/{{page.kong_version}}/pdk
+[Admin API]: /gateway/{{page.kong_version}}/admin-api/
+[Plugin Development Kit]: /gateway/{{page.kong_version}}/pdk

--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -82,7 +82,7 @@ considered closed and the `log` function is executed.
 [body_filter]: https://github.com/openresty/lua-nginx-module#body_filter_by_lua_block
 [log]: https://github.com/openresty/lua-nginx-module#log_by_lua_block
 [preread]: https://github.com/openresty/stream-lua-nginx-module#preread_by_lua_block
-[enable_buffering]: /gateway-oss/{{page.kong_version}}/pdk/kong.service.request/#kongservicerequestenable_buffering
+[enable_buffering]: /gateway/{{page.kong_version}}/pdk/kong.service.request/#kongservicerequestenable_buffering
 
 ---
 
@@ -297,4 +297,4 @@ post-function               | -1000
 Next: [Plugin configuration &rsaquo;]({{page.book.next}})
 
 [lua-nginx-module]: https://github.com/openresty/lua-nginx-module
-[pdk]: /gateway-oss/{{page.kong_version}}/pdk
+[pdk]: /gateway/{{page.kong_version}}/pdk

--- a/app/gateway/2.6.x/plugin-development/distribution.md
+++ b/app/gateway/2.6.x/plugin-development/distribution.md
@@ -290,7 +290,7 @@ reasons:
 * "plugin is enabled but not installed" -> The plugin's name is present in the
   `plugins` directive, but that Kong is unable to load the `handler.lua`
   source file from the file system. To resolve, make sure that the
-  [lua_package_path](/gateway-oss/{{page.kong_version}}/configuration/#development-miscellaneous-section)
+  [lua_package_path](/gateway/{{page.kong_version}}/reference/property-reference/#development-miscellaneous-section)
   directive is properly set to load this plugin's Lua sources.
 
 * "no configuration schema found for plugin" -> The plugin is installed,

--- a/app/gateway/2.6.x/plugin-development/entities-cache.md
+++ b/app/gateway/2.6.x/plugin-development/entities-cache.md
@@ -40,7 +40,7 @@ kong.plugins.<plugin_name>.daos
 ## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in
-your code by using the [kong.cache](/gateway-oss/{{page.kong_version}}/pdk/#kong-cache)
+your code by using the [kong.cache](/gateway/{{page.kong_version}}/pdk/#kong-cache)
 module provided by the [Plugin Development Kit]:
 
 ```
@@ -55,7 +55,7 @@ There are 2 levels of cache:
    all the workers. This can only hold scalar values, and hence requires
    (de)serialization of a more complex types such as Lua tables.
 
-When data is fetched from the database, it will be stored in both caches. 
+When data is fetched from the database, it will be stored in both caches.
 If the same worker process requests the data again, it will retrieve the
 previously deserialized data from the Lua memory cache. If a different
 worker within the same Nginx node requests that data, it will find the data
@@ -106,7 +106,7 @@ end
 
 function CustomHandler:access(config)
   CustomHandler.super.access(self)
-  
+
   -- retrieve the apikey from the request querystring
   local key = kong.request.get_query_arg("apikey")
 
@@ -124,14 +124,14 @@ function CustomHandler:access(config)
       message = "Unexpected error"
     })
   end
-    
+
   if not credential then
     -- no credentials in cache nor datastore
     return kong.response.exit(401, {
       message = "Invalid authentication credentials"
     })
   end
-    
+
   -- set an upstream header if the credential exists and is valid
   kong.service.request.set_header("X-API-Key", credential.apikey)
 end
@@ -285,7 +285,7 @@ module will store the miss just as if it was a hit. This means that a
 propagated by Kong so that all nodes that stored the miss can evict it, and
 properly fetch the newly created API key from the datastore.
 
-See the [Clustering Guide](/gateway-oss/{{page.kong_version}}/clustering/) to ensure
+See the [Clustering Guide](/gateway/{{page.kong_version}}/reference/clustering/) to ensure
 that you have properly configured your cluster for such invalidation events.
 
 ### Manual cache invalidation
@@ -347,5 +347,5 @@ extending the Admin API, which we will detail in the next chapter:
 
 Next: [Extending the Admin API &rsaquo;]({{page.book.next}})
 
-[Admin API]: /gateway-oss/{{page.kong_version}}/admin-api/
-[Plugin Development Kit]: /gateway-oss/{{page.kong_version}}/pdk
+[Admin API]: /gateway/{{page.kong_version}}/admin-api/
+[Plugin Development Kit]: /gateway/{{page.kong_version}}/pdk

--- a/app/gateway/2.6.x/plugin-development/file-structure.md
+++ b/app/gateway/2.6.x/plugin-development/file-structure.md
@@ -23,7 +23,7 @@ kong.plugins.<plugin_name>.<module_name>
 > Your modules of course need to be accessible through your
 > [package.path](http://www.lua.org/manual/5.1/manual.html#pdf-package.path)
 > variable, which can be tweaked to your needs via the
-> [lua_package_path](/gateway-oss/{{page.kong_version}}/configuration/#lua_package_path)
+> [lua_package_path](/gateway/{{page.kong_version}}/reference/property-reference/#lua_package_path)
 > configuration property.
 > However, the preferred way of installing plugins is through
 > [LuaRocks](https://luarocks.org/), which Kong natively integrates with.
@@ -31,7 +31,7 @@ kong.plugins.<plugin_name>.<module_name>
 
 To make Kong aware that it has to look for your plugin's modules, you'll have
 to add it to the
-[plugins](/gateway-oss/{{page.kong_version}}/configuration/#plugins) property in
+[plugins](/gateway/{{page.kong_version}}/reference/property-reference/#plugins) property in
 your configuration file, which is a comma-separated list. For example:
 
 ```yaml

--- a/app/gateway/2.6.x/plugin-development/index.md
+++ b/app/gateway/2.6.x/plugin-development/index.md
@@ -34,4 +34,4 @@ PDK, see the [Plugin Development Kit] reference.
 Next: [File structure of a plugin &rsaquo;]({{page.book.next}})
 
 [lua-nginx-module]: https://github.com/openresty/lua-nginx-module
-[Plugin Development Kit]: /gateway-oss/{{page.kong_version}}/pdk
+[Plugin Development Kit]: /gateway/{{page.kong_version}}/pdk

--- a/app/gateway/2.6.x/plugin-development/plugin-configuration.md
+++ b/app/gateway/2.6.x/plugin-development/plugin-configuration.md
@@ -37,7 +37,7 @@ database along with its configuration:
   foo = "bar"
 }
  ```
- 
+
 If the configuration is not valid, the Admin API would return `400 Bad Request`
 and the appropriate error messages.
 
@@ -159,7 +159,7 @@ Here is the list of some common (not all) accepted rules for a property (see the
 | Rule               | Description
 |--------------------|----------------------------
 | `type`             | The type of a property.
-| `required`         | Whether or not the property is required 
+| `required`         | Whether or not the property is required
 | `default`          | The default value for the property when not specified
 | `elements`         | Field definition of `array` or `set` elements.
 | `keys`             | Field definition of `map` keys.
@@ -175,8 +175,8 @@ You can also add field validators, to mention a few:
 | `between`          | Checks that the input number is between allowed values.
 | `eq`               | Checks the equality of the input to allowed value.
 | `ne`               | Checks the inequality of the input to allowed value.
-| `gt`               | Checks that the number is greater than given value. 
-| `len_eq`           | Checks that the input string length is equal to the given value. 
+| `gt`               | Checks that the number is greater than given value.
+| `len_eq`           | Checks that the input string length is equal to the given value.
 | `len_min`          | Checks that the input string length is at least the given value.
 | `len_max`          | Checks that the input string length is at most the given value.
 | `match`            | Checks that the input string matches the given Lua pattern.
@@ -295,7 +295,7 @@ return CustomHandler
 ```
 
 Note that the above example uses the
-[kong.log.inspect](/gateway-oss/{{page.kong_version}}/pdk/kong.log/#kong_log_inspect)
+[kong.log.inspect](/gateway/{{page.kong_version}}/pdk/kong.log/#kong_log_inspect)
 function of the [Plugin Development Kit] to print out those values to the Kong
 logs.
 
@@ -404,6 +404,6 @@ You can also see a real-world example of schema in [the Key-Auth plugin source c
 
 Next: [Accessing the Datastore &rsaquo;]({{page.book.next}})
 
-[Admin API]: /gateway-oss/{{page.kong_version}}/admin-api
-[Plugin Development Kit]: /gateway-oss/{{page.kong_version}}/pdk
+[Admin API]: /gateway/{{page.kong_version}}/admin-api
+[Plugin Development Kit]: /gateway/{{page.kong_version}}/pdk
 [the Key-Auth plugin source code]: https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/schema.lua

--- a/app/gateway/2.6.x/reference/cli.md
+++ b/app/gateway/2.6.x/reference/cli.md
@@ -265,7 +265,7 @@ Options:
 
 ---
 
-### kong runner 
+### kong runner
 {:.badge .enterprise}
 
 ```
@@ -350,4 +350,4 @@ Options:
 ---
 
 
-[configuration-reference]: /gateway-oss/{{page.kong_version}}/configuration
+[configuration-reference]: /gateway/{{page.kong_version}}/reference/property-reference/

--- a/app/gateway/2.6.x/reference/clustering.md
+++ b/app/gateway/2.6.x/reference/clustering.md
@@ -81,7 +81,7 @@ greatly reduces the load on the main database instance since read-only
 queries are no longer sent to it.
 
 To learn more about how to configure this feature, refer to the
-[Datastore section](/enterprise/{{page.kong_version}}/property-reference/#datastore-section)
+[Datastore section](/gateway/{{page.kong_version}}/reference/property-reference/#datastore-section)
 of the Configuration reference.
 
 ## What is being cached?

--- a/app/gateway/2.6.x/reference/clustering.md
+++ b/app/gateway/2.6.x/reference/clustering.md
@@ -286,6 +286,6 @@ If the node is receiving a lot of traffic, purging its cache at the same time
 will trigger many requests to your database, and could cause a
 [dog-pile effect](https://en.wikipedia.org/wiki/Cache_stampede).
 
-[db_update_frequency]: /gateway-oss/{{page.kong_version}}/configuration/#db_update_frequency
-[db_update_propagation]: /gateway-oss/{{page.kong_version}}/configuration/#db_update_propagation
-[db_cache_ttl]: /gateway-oss/{{page.kong_version}}/configuration/#db_cache_ttl
+[db_update_frequency]: /gateway/{{page.kong_version}}/reference/property-reference/#db_update_frequency
+[db_update_propagation]: /gateway/{{page.kong_version}}/reference/property-reference/#db_update_propagation
+[db_cache_ttl]: /gateway/{{page.kong_version}}/reference/property-reference/#db_cache_ttl

--- a/app/gateway/2.6.x/reference/health-checks-circuit-breakers.md
+++ b/app/gateway/2.6.x/reference/health-checks-circuit-breakers.md
@@ -341,12 +341,12 @@ All counter thresholds and intervals in `healthchecks` are zero by default,
 meaning that health checks are completely disabled by default in newly created
 upstreams.
 
-[ringbalancer]: /gateway-oss/{{page.kong_version}}/loadbalancing#ring-balancer
-[ringtarget]: /gateway-oss/{{page.kong_version}}/loadbalancing#target
-[upstream]: /gateway-oss/{{page.kong_version}}/loadbalancing#upstream
-[targetobject]: /gateway-oss/{{page.kong_version}}/admin-api#target-object
-[addupstream]: /gateway-oss/{{page.kong_version}}/admin-api#add-upstream
-[clustering]: /gateway-oss/{{page.kong_version}}/clustering
-[upstreamobjects]: /gateway-oss/{{page.kong_version}}/admin-api#upstream-objects
-[balancercaveats]: /gateway-oss/{{page.kong_version}}/loadbalancing#balancing-caveats
-[dnscaveats]: /gateway-oss/{{page.kong_version}}/loadbalancing#dns-caveats
+[ringbalancer]: /gateway/{{page.kong_version}}/reference/loadbalancing#ring-balancer
+[ringtarget]: /gateway/{{page.kong_version}}/reference/loadbalancing#target
+[upstream]: /gateway/{{page.kong_version}}/reference/loadbalancing#upstream
+[targetobject]: /gateway/{{page.kong_version}}/admin-api#target-object
+[addupstream]: /gateway/{{page.kong_version}}/admin-api#add-upstream
+[clustering]: /gateway/{{page.kong_version}}/reference/clustering
+[upstreamobjects]: /gateway/{{page.kong_version}}/admin-api#upstream-objects
+[balancercaveats]: /gateway/{{page.kong_version}}/reference/loadbalancing#balancing-caveats
+[dnscaveats]: /gateway/{{page.kong_version}}/reference/loadbalancing#dns-caveats

--- a/app/gateway/2.6.x/reference/loadbalancing.md
+++ b/app/gateway/2.6.x/reference/loadbalancing.md
@@ -341,8 +341,8 @@ The changes through the Kong Admin API are dynamic and will take
 effect immediately. No reload or restart is required, and no in progress
 requests will be dropped.
 
-[upstream-object-reference]: /gateway-oss/{{page.kong_version}}/admin-api#upstream-object
-[target-object-reference]: /gateway-oss/{{page.kong_version}}/admin-api#target-object
-[dns-order-config]: /gateway-oss/{{page.kong_version}}/configuration/#dns_order
-[real-ip-config]: /gateway-oss/{{page.kong_version}}/configuration/#real_ip_header
+[upstream-object-reference]: /gateway/{{page.kong_version}}/admin-api#upstream-object
+[target-object-reference]: /gateway/{{page.kong_version}}/admin-api#target-object
+[dns-order-config]: /gateway/{{page.kong_version}}/reference/property-reference/#dns_order
+[real-ip-config]: /gateway/{{page.kong_version}}/reference/property-reference/#real_ip_header
 [blue-green-canary]: http://blog.christianposta.com/deploy/blue-green-deployments-a-b-testing-and-canary-releases/

--- a/app/gateway/2.6.x/reference/property-reference.md
+++ b/app/gateway/2.6.x/reference/property-reference.md
@@ -2070,7 +2070,7 @@ happens on a service, the event hook calls a URL with information about that
 event. Event hook configurations differ depending on the handler. The events
 that are triggered send associated data.
 
-See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/
+See: https://docs.konghq.com/gateway/latest/admin-api/event-hooks/reference/
 
 **Default:** `on`
 
@@ -3337,7 +3337,7 @@ Different strategies are available to tune how to enforce splitting traffic of
 workspaces.
 
 - `smart` is the default option and uses the algorithm described in
-  https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces
+  https://docs.konghq.com/gateway/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces
 - `off` disables any check
 - `path` enforces routes to comply with the pattern described in config
   enforce_route_path_pattern

--- a/app/gateway/2.6.x/reference/proxy.md
+++ b/app/gateway/2.6.x/reference/proxy.md
@@ -1089,8 +1089,8 @@ subdomains, instead of creating an SNI for each.
 Valid wildcard positions are `mydomain.*`, `*.mydomain.com`, and `*.www.mydomain.com`.
 
 A default certificate can be added using the following parameters in Kong configuration:
-1. [`ssl_cert`](/gateway-oss/latest/configuration/#ssl_cert)
-2. [`ssl_cert_key`](/gateway-oss/latest/configuration/#ssl_cert_key)
+1. [`ssl_cert`](/gateway/{{page.kong_version}}/reference/property-reference/#ssl_cert)
+2. [`ssl_cert_key`](/gateway/{{page.kong_version}}/reference/property-reference/#ssl_cert_key)
 
 Or, by dynamically configuring the default certificate with an SNI of `*`:
 
@@ -1339,17 +1339,17 @@ If you haven't already, we suggest that you also read the [Load balancing
 Reference][load-balancing-reference], as it closely relates to the topic we
 just covered.
 
-[plugin-configuration-object]: /gateway-oss/{{page.kong_version}}/admin-api#plugin-object
-[plugin-development-guide]: /gateway-oss/{{page.kong_version}}/plugin-development
-[plugin-association-rules]: /gateway-oss/{{page.kong_version}}/admin-api/#precedence
-[proxy-websocket]: /gateway-oss/{{page.kong_version}}/proxy/#proxy-websocket-traffic
-[load-balancing-reference]: /gateway-oss/{{page.kong_version}}/loadbalancing
-[configuration-reference]: /gateway-oss/{{page.kong_version}}/configuration/
-[configuration-trusted-ips]: /gateway-oss/{{page.kong_version}}/configuration/#trusted_ips
-[configuring-a-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service
-[API]: /gateway-oss/{{page.kong_version}}/admin-api
-[service-entity]: /gateway-oss/{{page.kong_version}}/admin-api/#add-service
-[route-entity]: /gateway-oss/{{page.kong_version}}/admin-api/#add-route
+[plugin-configuration-object]: /gateway/{{page.kong_version}}/admin-api#plugin-object
+[plugin-development-guide]: /gateway/{{page.kong_version}}/plugin-development
+[plugin-association-rules]: /gateway/{{page.kong_version}}/admin-api/#precedence
+[proxy-websocket]: /gateway/{{page.kong_version}}/reference/proxy/#proxy-websocket-traffic
+[load-balancing-reference]: /gateway/{{page.kong_version}}/reference/loadbalancing
+[configuration-reference]: /gateway/{{page.kong_version}}/reference/property-reference/
+[configuration-trusted-ips]: /gateway/{{page.kong_version}}/reference/property-reference/#trusted_ips
+[configuring-a-service]: /gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service
+[API]: /gateway/{{page.kong_version}}/admin-api
+[service-entity]: /gateway/{{page.kong_version}}/admin-api/#add-service
+[route-entity]: /gateway/{{page.kong_version}}/admin-api/#add-route
 
 [ngx-http-proxy-module]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html
 [ngx-http-realip-module]: http://nginx.org/en/docs/http/ngx_http_realip_module.html
@@ -1359,5 +1359,5 @@ just covered.
 [ngx-server-port-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_server_port
 [ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
-[conf-grpc-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[conf-grpc-service]: /gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-grpc-service
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway/2.6.x/vitals/index.md
+++ b/app/gateway/2.6.x/vitals/index.md
@@ -1,8 +1,7 @@
 ---
 title: Vitals Overview
+badge: enterprise
 ---
-
-## Overview
 
 Use Kong Vitals (Vitals) to monitor {{site.ee_product_name}} health and performance, and to understand the microservice API transactions traversing Kong. Vitals uses visual API analytics to see exactly how your APIs and Gateway are performing. Quickly access key statistics, monitor vital signs, and pinpoint anomalies in real time.
 
@@ -10,11 +9,9 @@ Use Kong Vitals (Vitals) to monitor {{site.ee_product_name}} health and performa
 
 * Use Kong Manager to view visualizations of Vitals data, including the Workspaces Overview Dashboard, Workspace Charts, Vitals tab, and Status Codes, and to generate CSV Reports.
 
-
 ![Vitals Overview](/assets/images/docs/ee/vitals_overview.png)
 
-
-### Prerequisites
+## Prerequisites
 Vitals is enabled by default in {{site.ee_product_name}} and available upon the first login of a Super Admin.
 
 You will need one of the following databases to use Vitals:
@@ -22,7 +19,7 @@ You will need one of the following databases to use Vitals:
 * PostgresSQL 9.5+
 * Cassandra 2.1+
 
-### Guidelines for viewing Vitals
+## Guidelines for viewing Vitals
 When using Vitals, note:
 * Vitals is enabled by default and accessible the first time a Super Admin logs in.
   * To enable or disable Vitals, see [Enable or Disable Vitals](#enable-or-disable-vitals).
@@ -31,7 +28,7 @@ When using Vitals, note:
   * If a user does not have access to Vitals data, charts will not display.
 
 ## Vitals API
-Vitals data is available via endpoints on Kong’s Admin API. Access to these endpoints may be controlled via Admin API RBAC. The Vitals API is described in the OAS (Open API Spec, formerly Swagger) file. See a sample here (downloadable file): [`vitalsSpec.yaml`](/enterprise/{{page.kong_version}}/vitals/vitalsSpec.yaml).
+Vitals data is available via endpoints on Kong’s Admin API. Access to these endpoints may be controlled via Admin API RBAC. The Vitals API is described in the OAS (Open API Spec, formerly Swagger) file. See a sample here (downloadable file): [`vitalsSpec.yaml`](/gateway/{{page.kong_version}}/vitals/vitalsSpec.yaml).
 
 ## Viewing Vitals in Kong Manager
 View Vitals information in Kong Manager using any of the following:
@@ -40,13 +37,13 @@ View Vitals information in Kong Manager using any of the following:
 * Vitals tab, which provides detailed information about your Kong cluster, including total requests, latency, and cache information.
 * Status Codes to view cluster-wide status code classes.
 
-### Overview Dashboard
+## Overview Dashboard
 When you log in to Kong Manager, the Workspaces page displays by default. The top of the page displays the Vitals Overview Dashboard summarizing your Kong cluster, including the health and performance of your APIs and Gateway, total requests, average error rate, total consumers, and total services. This Vitals Overview Dashboard makes it easy for an Admin to quickly identify any issues that need attention.
 
-### Workspace charts
+## Workspace charts
 On the Workspaces page, beneath the Overview Dashboard, the Workspaces section displays each Workspace with a chart showing Vitals for the most recently added services, consumers, and plugins for that Workspace. Hover over a coordinate to view the exact number of successes and errors at a given timestamp, or drilldown into the Workspace chart for more details.
 
-### Vitals tab
+## Vitals tab
 The Vitals tab, or Vitals view, displays metrics about the health and performance of Kong nodes and Kong-proxied APIs. The Vitals View displays total requests, latency, and cache information. You also can generate reports from the Vitals view.
 
 Options to populate the Vitals view, or areas in the chart, include:
@@ -58,8 +55,8 @@ Options to populate the Vitals view, or areas in the chart, include:
 | Total Requests           | The Total Requests chart displays a count of all proxy requests received. This includes requests that were rejected due to rate-limiting, failed authentication, and so on.|
 | Cluster and Node Data    | Metrics are displayed on Vitals charts at both node and cluster level. Controls are available to show cluster-wide metrics and/or node-specific metrics. Clicking on individual nodes will toggle the display of data from those nodes. Nodes are identified by a unique Kong node identifier, by hostname, or by a combination of the two.|
 
-### Status Codes
-The Status Codes view displays visualizations of cluster-wide status code classes (1xx, 2xx, 3xx, 4xx, 5xx). The Status Codes view contains the counts of status code classes graphed over time, as well as the ratio of code classes to total requests. See [Status Codes](/enterprise/{{page.kong_version}}/vitals/vitals-metrics/#status-code).
+## Status Codes
+The Status Codes view displays visualizations of cluster-wide status code classes (1xx, 2xx, 3xx, 4xx, 5xx). The Status Codes view contains the counts of status code classes graphed over time, as well as the ratio of code classes to total requests. See [Status Codes](/gateway/{{page.kong_version}}/vitals/vitals-metrics/#status-code).
 
 >**Note**: The Status Codes view does not include non-standard code classes (6xx, 7xx, etc.). Individual status code data can be viewed in the Consumer, Route, and Service details pages under the Activity tab. Both standard and non-standard status codes are visible in these views.
 

--- a/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
@@ -1,8 +1,7 @@
 ---
 title: Vitals with InfluxDB
+badge: enterprise
 ---
-
-## Improve Vitals performance with InfluxDB
 
 Leveraging a time series database for Vitals data
 can improve request and Vitals performance in very-high traffic {{site.ee_product_name}}
@@ -12,11 +11,11 @@ backing the Kong cluster.
 
 For information about using Kong Vitals with a database as the backend (for example,
 PostgreSQL, Cassandra), refer to
-[Kong Vitals](/enterprise/{{page.kong_version}}/admin-api/vitals/).
+[Kong Vitals](/gateway/{{page.kong_version}}/admin-api/vitals/).
 
-## Setting up Kong Vitals with InfluxDB
+## Set up Kong Vitals with InfluxDB
 
-### Step 1. Install Kong Gateway
+### Install Kong Gateway
 
 If you already have a {{site.base_gateway}} instance, skip to [Step 2](#step-2-deploy-a-kong-gateway-enterprise-license).
 
@@ -25,7 +24,7 @@ will work for the purposes of this guide.
 
 {% include /md/2.4.x/docker-install-steps.md heading="#### " heading1="#### " heading2="#### " heading3="#### " %}
 
-#### Start the gateway with Kong Manager
+### Start the gateway with Kong Manager
 
 ```bash
 $ docker run -d --name kong-ee --network=kong-ee-net \
@@ -56,7 +55,7 @@ $ docker run -d --name kong-ee --network=kong-ee-net \
 with with the DNS name or IP of the Docker host. <code>KONG_ADMIN_GUI_URL</code>
 _should_ have a protocol, for example, `http://`.
 
-### Step 2. Deploy a Kong Gateway (Enterprise) license
+### Deploy a Kong Gateway (Enterprise) license
 
 If you already have a {{site.ee_product_name}} license attached to your {{site.base_gateway}}
 instance, skip to [Step 3](#step-3-start-an-influxdb-database).
@@ -66,7 +65,7 @@ You will not be able to access the Kong Vitals functionality without a valid
 
 {% include /md/enterprise/deploy-license.md heading="####" %}
 
-### Step 3. Start an InfluxDB database
+### Start an InfluxDB database
 
 Production-ready InfluxDB installations should be deployed as a separate
 effort, but for proof-of-concept testing, running a local InfluxDB instance
@@ -87,7 +86,7 @@ InfluxDB 2.0 will **not** work.
 Writing Vitals data to InfluxDB requires that the `kong` database is created,
 this is done using the `INFLUXDB_DB` variable.
 
-### Step 4. Configure Kong Gateway
+### Configure Kong Gateway
 
 {:.note}
 > **Note:** If you used the configuration in
@@ -210,14 +209,14 @@ worker process flushes its buffer of metrics every 5 seconds or 5000 data points
 whichever comes first.
 
 Metrics points are written with microsecond (`u`) precision. To comply with
-the [Vitals API](/enterprise/{{page.kong_version}}/admin-api/vitals/#vitals-api), measurement
+the [Vitals API](/gateway/{{page.kong_version}}/admin-api/vitals/#vitals-api), measurement
 values are read back grouped by second.
 
 {:.note}
 > **Note:** Because of limitations in the OpenResty API, writing values with
 microsecond precision requires an additional syscall per request.
 
-## Managing the retention policy of the kong database
+## Managing the retention policy of the Kong database
 
 Vitals InfluxDB data points are not downsampled or managed by a
 retention policy through Kong. InfluxDB operators are encouraged to manually manage

--- a/app/gateway/2.6.x/vitals/vitals-metrics.md
+++ b/app/gateway/2.6.x/vitals/vitals-metrics.md
@@ -1,9 +1,7 @@
 ---
 title: Vitals Metrics
+badge: enterprise
 ---
-
-
-## Using Vitals Metrics
 
 Vitals metrics fall into two categories:
 * Health Metrics — for monitoring the health of a Kong cluster
@@ -11,7 +9,7 @@ Vitals metrics fall into two categories:
 
 
 All metrics are collected at 1-second intervals and aggregated into 1-minute
-intervals. The 1-second intervals are retained for one hour. The 1-minute 
+intervals. The 1-second intervals are retained for one hour. The 1-minute
 intervals are retained for 25 hours.
 
 If longer retention times are needed, the Vitals API can be used to pull metrics
@@ -19,20 +17,20 @@ out of Kong and into a data retention tool.
 
 ## Health Metrics
 
-Health metrics give insight into the performance of a Kong cluster; for example, 
+Health metrics give insight into the performance of a Kong cluster; for example,
 how many requests the cluster is processing and the latency on those requests.
 
 Health metrics are tracked for each node in a cluster as well as for the cluster
-as a whole. In Kong, a node is a running process with a unique identifier, 
-configuration, cache layout, and connections to both Kong’s datastores and the 
-upstream APIs it proxies. Note that node identifiers are unique to the process, 
-and not to the host on which the process runs. In other words, each Kong restart 
+as a whole. In Kong, a node is a running process with a unique identifier,
+configuration, cache layout, and connections to both Kong’s datastores and the
+upstream APIs it proxies. Note that node identifiers are unique to the process,
+and not to the host on which the process runs. In other words, each Kong restart
 results in a new node, and therefore a new node ID.
 
 ### Latency
 
-The Vitals API may return null for Latency metrics. This occurs when no API 
-requests were proxied during the timeframe. Null latencies are not graphed in 
+The Vitals API may return null for Latency metrics. This occurs when no API
+requests were proxied during the timeframe. Null latencies are not graphed in
 Kong Manager; periods with null latencies appear as gaps in Vitals charts.
 
 #### Proxy Latency (Request)

--- a/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
@@ -1,5 +1,6 @@
 ---
 title: Vitals with Prometheus
+badge: enterprise
 ---
 
 This document covers integrating Kong Vitals with a new or existing Prometheus
@@ -10,7 +11,7 @@ requests per second), without placing addition write load on the database
 backing the Kong cluster.
 
 For using Vitals with a database as the backend (i.e. PostgreSQL, Cassandra),
-please refer to [Kong Vitals](/enterprise/{{page.kong_version}}/admin-api/vitals/).
+please refer to [Kong Vitals](/gateway/{{page.kong_version}}/admin-api/vitals/).
 
 ## Lifecycle Overview
 
@@ -37,7 +38,7 @@ or as a sidecar/adjacent process within a VM. Note that in high-traffic environm
 within the StatsD exporter process can cause significant CPU usage. In such cases, we recommend to
 run Kong and StatsD processes on separate hardware/VM/container environments to avoid saturating CPU usage.
 
-## Setup Prometheus environment for Vitals
+## Set up Prometheus environment for Vitals
 
 ### Download Prometheus
 
@@ -233,7 +234,7 @@ $ ./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
 ## Exported Metrics
 
 With the above configuration, the Prometheus StatsD exporter will make available all
-metrics as provided by the [standard Vitals configuration](/enterprise/{{page.kong_version}}/admin-api/vitals/#vitals-metrics).
+metrics as provided by the [standard Vitals configuration](/gateway/{{page.kong_version}}/admin-api/vitals/#vitals-metrics).
 
 Additionally, the exporter process provides access to the default metrics exposed by the [Golang
 Prometheus client library](https://prometheus.io/docs/guides/go-application/). These metric names

--- a/app/gateway/2.6.x/vitals/vitals-reports.md
+++ b/app/gateway/2.6.x/vitals/vitals-reports.md
@@ -1,8 +1,7 @@
 ---
 title: Vitals Reports
+badge: enterprise
 ---
-
-## Using Vitals Reports
 
 Browse, filter, and view your data in a Vitals time-series report, and export the data into a comma-separated values (CSV) file.
 
@@ -17,7 +16,7 @@ When generating a Vitals report, you can:
 ## Prerequisites
 
 InfluxDB database installed and configured. For more information, see
-[Vitals with InfluxDB](/enterprise/{{page.kong_version}}/vitals/vitals-influx-strategy/).  
+[Vitals with InfluxDB](/gateway/{{page.kong_version}}/vitals/vitals-influx-strategy/).  
 
 **Important**: The Vitals Reports feature is not compatible with a Postgres or Cassandra database. If using one of these databases, the Reports button will not display on the Vitals view.
 
@@ -39,7 +38,7 @@ To create a time-series report containing Vitals data, complete the steps in thi
     | *Interval*               | Select the time interval to display in the report: weeks, hours, days, minutes. If you select an interval that is out of the available range, the results return zeroes. |
 
 
-4. A Vitals report generates, starting with a summary of data in your report, including Id, Name, App Name, App Id, and Total. Note that the App Name and App Id are dependent on the Dev Portal App Registration plugin. For more information about status codes (2XX, 4XX, etc), see [_Vitals Metrics_](/enterprise/{{page.kong_version}}/vitals/vitals-metrics/).
+4. A Vitals report generates, starting with a summary of data in your report, including Id, Name, App Name, App Id, and Total. Note that the App Name and App Id are dependent on the Dev Portal App Registration plugin. For more information about status codes (2XX, 4XX, etc), see [_Vitals Metrics_](/gateway/{{page.kong_version}}/vitals/vitals-metrics/).
 
 5. To download your report, click **Export**. A CSV file containing your Vitals report data downloads to your system.  
 


### PR DESCRIPTION
### Summary
* Updating all /enterprise/ and /gateway-oss/ links in the new folder to point to /gateway/
* Applying badges to enterprise and free mode topics
* In topics where I fixed links or applied badges, also:
  * Fixing header levels in topics where I fixed links
  * Removing redundant "Introduction" and "overview" headers 

### Reason
Single-sourcing project.
Originally, had planned on not updating links and relying on redirects, but this is not a good long-term strategy for SEO.

### Testing
Tested locally. Will need to be heavily tested during bug bash.
