### PR TITLE
Revert Konnect Platform section name

### DIFF
--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -49,7 +49,7 @@
         </li>
         <hr>
         <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect_platform' %} class="active"{% endif %}>
-          <a href="/konnect-platform/" {% if include.edition == 'konnect_platform' %}class="active"{% endif %}>Common documentation</a>
+          <a href="/konnect-platform/" {% if include.edition == 'konnect_platform' %}class="active"{% endif %}>Kong Konnect Platform</a>
         </li>
         <hr>
         <li role="menuitem" tabindex="-1" {% if include.edition == 'contributing' %} class="active"{% endif %}>

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -63,7 +63,7 @@
               </li>
               <hr>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/konnect-platform/" class="navbar-item navbar-item-docs">Common documentation</a>
+                <a href="/konnect-platform/" class="navbar-item navbar-item-docs">Kong Konnect Platform</a>
               </li>
               <hr>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">


### PR DESCRIPTION
### Summary
Change "Common documentation" menu item back to "Kong Konnect Platform".

### Reason
"Common documentation" was a placeholder and was causing confusion, and we can't think of anything better than what it was before.

### Testing
Tested locally.