### PR TITLE
(Bug bash) fix broken links

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -95,8 +95,8 @@
       url: /plan-and-deploy/dns-considerations
     - text: Default Ports
       url: /plan-and-deploy/default-ports
-    - text: Licensing
-      url: /plan-and-deploy/licenses/licensing
+    - text: Licenses
+      url: /plan-and-deploy/licenses
       items:
         - text: Access Your License
           url: /plan-and-deploy/licenses/access-license
@@ -105,7 +105,6 @@
         - text: Monitor License Usage
           url: /plan-and-deploy/licenses/report
     - text: Security
-      url: /plan-and-deploy/security
       items:
         - text: Start Kong Gateway Securely
           url: /plan-and-deploy/security/start-kong-securely

--- a/app/_includes/md/enterprise/download/statsd.md
+++ b/app/_includes/md/enterprise/download/statsd.md
@@ -18,13 +18,13 @@ be downloaded at
 Then start StatsD exporter with
 
 ```bash
-$ ./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
+./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
                     --statsd.listen-unixgram=''
 ```
 
 The StatsD mapping rules file must be configured to match the metrics sent from
 Kong. To learn how to customize the StatsD events name, please refer to
-[Enable Vitals with Prometheus strategy in Kong](#enable-Vitals-with-prometheus-strategy-in-kong)
+[Enable Vitals with Prometheus strategy in Kong](#enable-vitals-with-prometheus-strategy-in-kong)
 section.
 
 {% if include.version == "<1.3" %}

--- a/app/_includes/md/gateway/root-user-note.md
+++ b/app/_includes/md/gateway/root-user-note.md
@@ -10,4 +10,4 @@ and Seed Super Admin.
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see
-[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}//plan-and-deploy/kong-user).
+[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/plan-and-deploy/kong-user).

--- a/app/_includes/md/gateway/root-user-note.md
+++ b/app/_includes/md/gateway/root-user-note.md
@@ -10,4 +10,4 @@ and Seed Super Admin.
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see
-[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/deployment/kong-user).
+[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}//plan-and-deploy/kong-user).

--- a/app/_includes/md/installation.md
+++ b/app/_includes/md/installation.md
@@ -59,19 +59,19 @@ information, see [Running Kong as a Non-Root User](/gateway/{{page.kong_version}
 
 1. Start {{site.base_gateway}}:
     ```bash
-    $ kong start [-c /path/to/kong.conf]
+    kong start [-c /path/to/kong.conf]
     ```
 
 2. Check that {{site.base_gateway}} is running:
 
     ```bash
-    $ curl -i http://localhost:8001/
+    curl -i http://localhost:8001/
     ```
 
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/gateway/{{include.kong_version}}/get-started/overview) guides to get the most
+[Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive) guides to get the most
 out of {{site.base_gateway}}.
 
 [configuration]: /gateway-oss/{{site.data.kong_latest.release}}/configuration/#database

--- a/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
@@ -40,7 +40,7 @@ In the following sections, you will need the `kong_admin` account’s password t
 {% navtabs %}
 {% navtab Using Kong Manager %}
 
-#### Log into Kong Manager
+### Log into Kong Manager
 
 1. Go to Kong Manager, or reload the page if you already have it open and you will see the following login screen.
 2. Log in to Kong Manager with the built-in Super Admin account, `kong_admin`, and its password.
@@ -132,7 +132,7 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
-#### Invite a New Admin
+### Invite a New Admin
 
 <div class="alert alert-warning">
 <strong>Note:</strong> If you also use the Admin API, once you've created this admin, you can find it under the <em>/admins</em> endpoint.</div>

--- a/app/gateway/2.6.x/get-started/quickstart/adding-consumers.md
+++ b/app/gateway/2.6.x/get-started/quickstart/adding-consumers.md
@@ -8,7 +8,8 @@ associated to individuals using your Service, and can be used for tracking, acce
 management, and more.
 
 ## Before you start
-* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
+
+* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/).
 * You have [configured a Service](/gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service)
 * You have [enabled the key-auth plugin](/gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins)
 

--- a/app/gateway/2.6.x/get-started/quickstart/adding-consumers.md
+++ b/app/gateway/2.6.x/get-started/quickstart/adding-consumers.md
@@ -9,7 +9,7 @@ management, and more.
 
 ## Before you start
 
-* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/).
+* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
 * You have [configured a Service](/gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service)
 * You have [enabled the key-auth plugin](/gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins)
 

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-grpc-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-grpc-service.md
@@ -21,7 +21,8 @@ for how to). In this guide, we will assume Kong is listening for HTTP/2 proxy
 requests on port 9080.
 
 ## Before you start
-You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
+
+You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/).
 
 ## 1. Single gRPC Service and Route
 

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-grpc-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-grpc-service.md
@@ -22,7 +22,7 @@ requests on port 9080.
 
 ## Before you start
 
-You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/).
+You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
 
 ## 1. Single gRPC Service and Route
 

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
@@ -20,7 +20,7 @@ Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, i
 Routes, is made via requests on that API.
 
 ## Before you start
-You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
+You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/).
 
 ## 1. Add your Service using the Admin API
 

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
@@ -20,7 +20,7 @@ Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, i
 Routes, is made via requests on that API.
 
 ## Before you start
-You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/).
+You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run).
 
 ## 1. Add your Service using the Admin API
 

--- a/app/gateway/2.6.x/get-started/quickstart/enabling-plugins.md
+++ b/app/gateway/2.6.x/get-started/quickstart/enabling-plugins.md
@@ -16,7 +16,7 @@ from unauthorized use.
 
 ## Before you start
 
-* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/)
+* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run)
 * You have [configured your Service](/gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service) in {{site.base_gateway}}
 
 ## 1. Configure the key-auth plugin

--- a/app/gateway/2.6.x/get-started/quickstart/enabling-plugins.md
+++ b/app/gateway/2.6.x/get-started/quickstart/enabling-plugins.md
@@ -15,7 +15,8 @@ other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
 ## Before you start
-* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install-and-run)
+
+* You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started/quickstart) or a more [comprehensive installation](/gateway/{{page.kong_version}}/get-started/comprehensive/)
 * You have [configured your Service](/gateway/{{page.kong_version}}/get-started/quickstart/configuring-a-service) in {{site.base_gateway}}
 
 ## 1. Configure the key-auth plugin

--- a/app/gateway/2.6.x/get-started/quickstart/index.md
+++ b/app/gateway/2.6.x/get-started/quickstart/index.md
@@ -9,7 +9,7 @@ API, where you'll manage entities including Services, Routes, and Consumers.
 
 One quick way to get Kong Gateway up and running is by using [Docker with a PostgreSQL database](/gateway/{{page.kong_version}}/install-and-run/docker). We recommend this method to test out basic Kong Gateway functionality.
 
-For a comprehensive list of installation options, see our [Kong Community Install page](https://konghq.com/install/#kong-community).
+For a comprehensive list of installation options, see our [Install page](/gateway/{{page.kong_version}}/install-and-run/).
 
 1. Create a Docker network:
 

--- a/app/gateway/2.6.x/install-and-run/index.md
+++ b/app/gateway/2.6.x/install-and-run/index.md
@@ -81,5 +81,5 @@ contact your sales representative.
 
 {:.note}
 > **Note:** The free mode does not require a license. See
-[Kong Gateway Licensing](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/licensing)
+[Kong Gateway Licensing](/gateway/{{page.kong_version}}/plan-and-deploy/licenses)
 for a feature comparison.

--- a/app/gateway/2.6.x/install-and-run/migrate-ce-to-ke.md
+++ b/app/gateway/2.6.x/install-and-run/migrate-ce-to-ke.md
@@ -20,7 +20,7 @@ supports the same {{site.ce_product_name}} version.
    {{site.ce_product_name}} to {{site.ee_product_name}}.
 
 * If running a version of {{site.ce_product_name}} earlier than 2.6.x,
-  [upgrade to Kong 2.6.x](/gateway/{{page.kong_version}}/upgrade-oss/) before migrating
+  [upgrade to Kong 2.6.x](/gateway/{{page.kong_version}}/install-and-run/upgrade-oss/) before migrating
   {{site.ce_product_name}} to {{site.ee_product_name}} 2.6.x.
 
 ## Migration steps

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -3,6 +3,7 @@ title: Deploy Kong Gateway in Hybrid Mode
 ---
 
 ## Prerequisites
+
 To get started with a Hybrid mode deployment, first install an instance of
 {{site.base_gateway}} with TLS to be your Control Plane (CP) node. See the
 [installation documentation](/gateway/{{page.kong_version}}/install-and-run/)
@@ -15,6 +16,7 @@ We will bring up any subsequent Data Plane (DP) instances in this topic.
 in the `kong/charts` repository.
 
 ## Generate a certificate/key pair
+
 In Hybrid mode, a mutual TLS handshake (mTLS) is used for authentication so the
 actual private key is never transferred on the network, and communication
 between CP and DP nodes is secure.
@@ -41,7 +43,7 @@ For a breakdown of the properties used by these modes, see the
 
 1. On an existing {{site.base_gateway}} instance, create a certificate/key pair:
     ```bash
-    $ kong hybrid gen_cert
+    kong hybrid gen_cert
     ```
     This will generate `cluster.crt` and `cluster.key` files and save them to
     the current directory. By default, the certificate/key pair is valid for three
@@ -262,10 +264,10 @@ keys.
 
 2. Next, start Kong, or reload Kong if it's already running:
     ```bash
-    $ kong start
+    kong start
     ```
     ```bash
-    $ kong reload
+    kong reload
     ```
 
 {% endnavtab %}
@@ -308,7 +310,7 @@ keys.
 
 2. Restart Kong for the settings to take effect:
     ```bash
-    $ kong restart
+    kong restart
     ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -371,18 +373,18 @@ on how data plane nodes process configuration.
 {% navtab Using Docker %}
 1. Using the [Docker installation documentation](/gateway/{{page.kong_version}}/install-and-run/docker),
 follow the instructions to:
-    1. [Download {{site.base_gateway}}](/gateway/{{page.kong_version}}/install-and-run/docker#pull-image).
-    2. [Create a Docker network](/gateway/{{page.kong_version}}/install-and-run/docker/#create-network).
+    1. [Download {{site.base_gateway}}](/gateway/{{page.kong_version}}/install-and-run/docker).
+    2. [Create a Docker network](/gateway/{{page.kong_version}}/install-and-run/docker/#install-gateway-in-db-less-mode).
 
     {:.warning}
     > **Warning:** Do not start or create a database on this node.
 
 
-2. Bring up your Data Plane container with the following settings:
+1. Bring up your Data Plane container with the following settings:
 
     For `shared` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    docker run -d --name kong-ee-dp1 --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -397,7 +399,7 @@ follow the instructions to:
 
     For `pki` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    docker run -d --name kong-ee-dp1 --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -440,7 +442,7 @@ follow the instructions to:
     `KONG_CLUSTER_TELEMETRY_ENDPOINT`
     : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
 
-3. If needed, bring up any subsequent Data Planes using the same settings.
+2. If needed, bring up any subsequent Data Planes using the same settings.
 
 {% endnavtab %}
 {% navtab Using kong.conf %}
@@ -510,7 +512,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
 
 3. Restart Kong for the settings to take effect:
     ```bash
-    $ kong restart
+    kong restart
     ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -528,12 +530,12 @@ following on a Control Plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-$ curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}
 ```bash
-$ http :8001/clustering/data-planes
+http :8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -564,6 +566,7 @@ The output shows all of the connected Data Plane instances in the cluster:
 ```
 
 ## References
+
 ### DP node start sequence
 
 When set as a DP node, {{site.base_gateway}} processes configuration in the

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/index.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/index.md
@@ -52,6 +52,7 @@ You can run {{site.base_gateway}} in Hybrid mode on any platform where
 {{site.base_gateway}} is [supported](/gateway/{{page.kong_version}}/install-and-run/).
 
 ### Kubernetes Support and Additional Documentation
+
 [Kong Enterprise on Kubernetes](/gateway/{{page.kong_version}}/install-and-run/kubernetes)
 fully supports Hybrid mode deployments, with or without the Kong Ingress Controller.
 
@@ -60,6 +61,7 @@ For the full Kubernetes Hybrid mode documentation, see
 in the `kong/charts` repository.
 
 ## Version Compatibility
+
 {{site.base_gateway}} control planes only allow connections from data planes with the
 same major version.
 Control planes won't allow connections from data planes with newer minor versions.
@@ -120,7 +122,7 @@ If a config can not be pushed to a data plane due to failure of the
 compatibility checks, the control plane will contain `warn` level lines in the
 `error.log` similar to the following:
 
-```
+```bash
 unable to send updated configuration to DP node with hostname: localhost.localdomain ip: 127.0.0.1 reason: version mismatches, CP version: 2.2 DP version: 2.1
 unable to send updated configuration to DP node with hostname: localhost.localdomain ip: 127.0.0.1 reason: CP and DP does not have same set of plugins installed or their versions might differ
 ```
@@ -167,6 +169,7 @@ the whole configuration in the referenced YAML file.
 ## Limitations
 
 ### Configuration Inflexibility
+
 When a configuration change is made at the Control Plane level via the Admin
 API, it immediately triggers a cluster-wide update of all Data Plane
 configurations. This means that the same configuration is synced from the CP to
@@ -174,6 +177,7 @@ all DPs, and the update cannot be scheduled or batched. For different DPs to
 have different configurations, they will need their own CP instances.
 
 ### Plugin Incompatibility
+
 When plugins are running on a Data Plane in hybrid mode, there is no Admin API
 exposed directly from that DP. Since the Admin API is only exposed from the
 Control Plane, all plugin configuration has to occur from the CP. Due to this
@@ -192,11 +196,13 @@ generate and delete tokens, and commit those changes to the database, which is
 not possible with CP/DP separation.
 
 ### Custom Plugins
+
 Custom plugins (either your own plugins or third-party plugins that are not
 shipped with Kong) need to be installed on both the Control Plane and the Data
 Plane in Hybrid mode.
 
 ### Load Balancing
+
 Currently, there is no automated load balancing for connections between the
 Control Plane and the Data Plane. You can load balance manually by using
 multiple Control Planes and redirecting the traffic using a TCP proxy.
@@ -206,7 +212,7 @@ multiple Control Planes and redirecting the traffic using a TCP proxy.
 Several readonly endpoints from the [Admin API](/gateway/{{page.kong_version}}/admin-api)
 are exposed to the [Status API](/gateway/{{page.kong_version}}/reference/property-reference/#status_listen) on data planes, including the following:
 
-- GET /upstreams/{upstream}/targets/
+- [GET /upstreams/{upstream}/targets/](/gateway/{{page.kong_version}}/admin-api/#list-targets)
 - [GET /upstreams/{upstream}/health/](/gateway/{{page.kong_version}}/admin-api/#show-upstream-health-for-node)
 - [GET /upstreams/{upstream}/targets/all/](/gateway/{{page.kong_version}}/admin-api/#list-all-targets)
 - GET /upstreams/{upstream}/targets/{target}

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/deploy-license.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/deploy-license.md
@@ -4,6 +4,6 @@ badge: enterprise
 ---
 
 Deploy an enterprise license to a {{site.base_gateway}} installation to gain access
-to [Enterprise-specific features](/gateway/{{page.kong_version}}/licenses).
+to [Enterprise-specific features](/gateway/{{page.kong_version}}/plan-and-deploy/licenses).
 
 {% include /md/enterprise/deploy-license.md heading="##" kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/index.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/index.md
@@ -46,10 +46,12 @@ CLI tool.
 For more information, see [Deploy Your License](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license).
 
 ## Examining the license data on a Kong Gateway node
+
 Retrieve license data using the Admin API's `/licenses` endpoint, or through
 the Admin GUI in Kong Manager.
 
 ## License expiration
+
 When a license expires, you will still have access to your {{site.base_gateway}}
 and its configuration. Any Enterprise-specific features will be locked, and
 the Admin API will not be accessible until the license is either renewed or the
@@ -60,12 +62,14 @@ features such Dev Portal, Immunity, Enterprise plugins, and others will no
 longer be accessible.
 
 ### License expiration logs
+
 {{site.base_gateway}} logs the license expiration date on the following schedule:
 * 90 days before: `WARN` log entry once a day
 * 30 days before: `ERR` log entry once a day
 * At and after expiration: `CRIT` log entry once a day
 
 ## Troubleshooting
+
 When a valid license file is properly deployed, license file validation is a transparent operation; no additional output or logging data is written or provided. If an error occurs when attempting to validate the license, or the license data is not valid, an error message will be written to the console and logged to the Kong error log, followed by the process quitting. Below are possible error messages and troubleshooting steps to take:
 
 `license path environment variable not set`

--- a/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
@@ -109,10 +109,10 @@ vitals_tsdb_address = prometheus-node:9090
 
 ```bash
 # or via environment variables
-$ export KONG_VITALS=on
-$ export KONG_VITALS_STRATEGY=prometheus
-$ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
-$ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
+export KONG_VITALS=on
+export KONG_VITALS_STRATEGY=prometheus
+export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
+export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
@@ -131,7 +131,7 @@ vitals_prometheus_scrape_interval = new_value_in_seconds
 
 ```bash
 # or via environment variables
-$ export KONG_VITALS_PROMETHEUS_SCRAPE_INTERVAL=new_value_in_seconds
+export KONG_VITALS_PROMETHEUS_SCRAPE_INTERVAL=new_value_in_seconds
 ```
 
 The above option configures `interval` parameter when querying Prometheus.
@@ -149,7 +149,7 @@ vitals_statsd_prefix = kong-vitals
 
 ```bash
 # or via environment variables
-$ export KONG_VITALS_STATSD_PREFIX=kong-vitals
+export KONG_VITALS_STATSD_PREFIX=kong-vitals
 ```
 
 ```yaml
@@ -189,7 +189,7 @@ To increase the UDP read buffer for the StatsD exporter process, run the binary
 using the following example to set read buffer to around 3 MB:
 
 ```
-$ ./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
+./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
                     --statsd.listen-unixgram='' \
                     --statsd.read-buffer=30000000
 ```
@@ -214,7 +214,7 @@ on the same node with Kong and let the exporter listen on local Unix domain
 socket.
 
 ```bash
-$ ./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
+./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
                     --statsd.read-buffer=30000000 \
                     --statsd.listen-unixgram='/tmp/statsd.sock'
 ```
@@ -225,7 +225,7 @@ By default the socket is created with permission `0755`, so that StatsD exporter
  users, the socket can be created with permission `0777` with the following:
 
 ```bash
-$ ./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
+./statsd_exporter --statsd.mapping-config=statsd.rules.yaml \
                     --statsd.read-buffer=30000000 \
                     --statsd.listen-unixgram='/tmp/statsd.sock' \
                     --statsd.unixsocket-umask="777"


### PR DESCRIPTION
### Summary

Addresses broken links found in bug bash for single-sourcing. 

DOCU-2000: /gateway/2.6.x/get-started/quickstart/ links to /gateway/2.6.x/install-and-run/ instead of community install page.
DOCU-2001: /gateway/2.6.x/install-and-run/debian/ links to /comprehensive instead of /overview
DOCU-2002: all links in /gateway/2.6.x/get-started/quickstart/ (see subpages) to comprehensive now go to /comprehensive
DOCU-2004: /gateway/2.6.x/install-and-run/migrate-ce-to-ke/ has fixed link to /gateway/2.6.x/install-and-run/upgrade-oss/
DOCU-2007: Added missing link to endpoint docs /gateway/2.6.x/plan-and-deploy/hybrid-mode/#readonly-status-api-endpoints-on-data-plane but could not find the find link. 
DOCU-2009: /gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup/ fixed anchor links
DOCU-2010: /gateway/2.6.x/plan-and-deploy/licenses/deploy-license/ first link now goes to license page (also fixed broken license link in the YAML menu config)
DOCU-2011: /gateway/2.6.x/install-and-run same link to license page issue remedied above
DOCU-2012: /gateway/2.6.x/plan-and-deploy/security/ fixed 404 by update YAML menu config to make this a toggle menu element, not a page link (we don't have an index.md security page)
DOCU-2013: same licensing page issue resolved
DOCU-2015: Vitals with Prometheus fixed broken anchor link in the include
DOCU-2019: /gateway/2.6.x/install-and-run/amazon-linux/ fixed Run Kong as Non-Root User includes
