### PR TITLE
[DOCU-2005][DOCU-2008] bug bash fixes

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -74,7 +74,6 @@
 
 - title: Plan and Deploy
   icon: /assets/images/icons/documentation/icn-deployment-color.svg
-  url: /plan-and-deploy
   items:
     - text: Running Kong as a Non-Root User
       url: /plan-and-deploy/kong-user

--- a/app/_includes/md/gateway/deployment-options.md
+++ b/app/_includes/md/gateway/deployment-options.md
@@ -1,4 +1,4 @@
 <!-- Deployment Options section; used in all Enterprise installation topics - except k8s -->
-The installation instructions assume that you are deploying {{site.base_gateway}} in [classic embedded mode](/gateway/{{include.kong_version}}/plan-and-deploy/deployment-options).
+The installation instructions explain how to deploy {{site.base_gateway}} in its entirety on a single node -- with or without a database.
 
-If you want to run {{site.base_gateway}} in Hybrid mode, the instructions in this topic will walk you though setting up a Control Plane instance. Afterward, you will need to bring up additional gateway instances for the Data Planes, and perform further configuration steps. See [Hybrid Mode Setup](/gateway/{{include.kong_version}}/plan-and-deploy/hybrid-mode-setup) for details.
+The instructions are the same for setting up a Control Plane instance in Hybrid mode. After you set up the Control Plane, you set up additional Gateway instances for the Data Planes. See [Hybrid Mode Setup](/gateway/{{include.kong_version}}/plan-and-deploy/hybrid-mode/hybrid-mode-setup) for details.

--- a/app/gateway/2.6.x/plan-and-deploy/index.md
+++ b/app/gateway/2.6.x/plan-and-deploy/index.md
@@ -1,6 +1,0 @@
----
-title: Plan and Deploy
----
-
-PLACEHOLDER
-TO DO: FILL THIS OUT


### PR DESCRIPTION
### Summary
Remove placeholder landing page for plan-and-deploy, rewrite deployment options intro for install pages

Deployment options rewrite is a bit drastic: removed link to old deployment options page and any mention of "embedded", added language about what the install actually does. PTAL, happy to make changes.

### Reason
single-sourcing

### Testing
tested locally
