### PR TITLE
[DOCU-2020] Left nav margin adjustment

### DIFF
--- a/app/_assets/stylesheets/accordion.less
+++ b/app/_assets/stylesheets/accordion.less
@@ -4,6 +4,7 @@
 .accordion-container {
   position: relative;
   margin: 0;
+  margin-bottom: 25px;
   padding: 0;
 
   li.accordion-item {


### PR DESCRIPTION
### Summary
Letting scrollbar go 25px past last menu item so that the bottom of the menu isn't cut off (or awkward to click on) by the screen.

This is the most quick-and-dirty solution I could go with; the navbar needs way more work (scroll to active item, for example - that would fix the problem more gracefully) but that is out of scope of this project.

### Reason
Difficulty dealing with References section of new gateway doc.

### Testing
Tested locally.
