### PR TITLE
[DOCU-2003] Single-source includes and update links

### DIFF
--- a/app/_includes/md/2.6.x/deployment-options-k8s.md
+++ b/app/_includes/md/2.6.x/deployment-options-k8s.md
@@ -1,4 +1,0 @@
-<!-- Deployment Options section; used in all Enterprise k8s installation topics-->
-The following instructions assume that you are deploying {{site.base_gateway}} in [classic embedded mode](/enterprise/{{include.kong_version}}/deployment/deployment-options).
-
-If you would like to run {{site.base_gateway}} in Hybrid mode, the instructions in this topic will walk you though setting up a Control Plane instance. Afterward, you will need to bring up additional gateway instances for the Data Planes, and perform further configuration steps. See [Hybrid Mode setup documentation](https://github.com/Kong/charts/blob/main/charts/kong#hybrid-mode) for details.

--- a/app/_includes/md/2.6.x/deployment-options.md
+++ b/app/_includes/md/2.6.x/deployment-options.md
@@ -1,4 +1,0 @@
-<!-- Deployment Options section; used in all Enterprise installation topics - except k8s -->
-The following instructions assume that you are deploying {{site.base_gateway}} in [classic embedded mode](/enterprise/{{include.kong_version}}/deployment/deployment-options).
-
-If you want to run {{site.base_gateway}} in Hybrid mode, the instructions in this topic will walk you though setting up a Control Plane instance. Afterward, you will need to bring up additional gateway instances for the Data Planes, and perform further configuration steps. See [Hybrid Mode Setup](/enterprise/{{include.kong_version}}/deployment/hybrid-mode-setup) for details.

--- a/app/_includes/md/2.6.x/ee-kong-user.md
+++ b/app/_includes/md/2.6.x/ee-kong-user.md
@@ -6,4 +6,4 @@ Amazon Linux 2, CentOS, Ubuntu, and RHEL -->
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see
-[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/deployment/kong-user).
+[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/plan-and-deploy/kong-user).

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -56,7 +56,7 @@ Result:
 ```
 
 For more detail and options, see the
-[Admin API `licenses` endpoint reference](/enterprise/{{include.kong_version}}/admin-api/licenses/examples/).
+[Admin API `licenses` endpoint reference](/gateway/latest/admin-api/licenses/examples/).
 
 {% endnavtab %}
 {% navtab Filesystem %}

--- a/app/_includes/md/enterprise/download/immunity.md
+++ b/app/_includes/md/enterprise/download/immunity.md
@@ -1,4 +1,4 @@
-{{site.base_gateway}}<!-- Version compatibility and download instructions for Brain and Immunity
+<!-- Version compatibility and download instructions for Brain and Immunity
 which is located in the install-configure.md file in the immuntiy folder -->
 
 {% if include.version == "1.5-2.1" %}

--- a/app/_includes/md/enterprise/turn-on-rbac.md
+++ b/app/_includes/md/enterprise/turn-on-rbac.md
@@ -34,4 +34,4 @@ The cookie is used for all subsequent requests to authenticate the user, until i
 {% endnavtab %}
 {% endnavtabs %}
 
-Outside of this guide, you will likely want to modify these settings differently, depending on your installation. You can read more about these settings here: [Basic Auth for Kong Manager](/enterprise/latest/kong-manager/authentication/basic/).
+Outside of this guide, you will likely want to modify these settings differently, depending on your installation. You can read more about these settings here: [Basic Auth for Kong Manager](/gateway/latest/configure/auth/kong-manager/basic/).

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -179,7 +179,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/gateway/{{include.kong_version}}/get-started/overview) guides to get the most
+[Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/_includes/md/installation.md
+++ b/app/_includes/md/installation.md
@@ -29,7 +29,7 @@ file for specifying the entities as a declarative configuration.
 
 ### Without a database
 
-If you are going to run Kong in [DB-less mode](/gateway-oss/{{site.data.kong_latest.release}}/db-less-and-declarative-config/),
+If you are going to run Kong in [DB-less mode](/gateway/{{include.kong_version}}/reference/db-less-and-declarative-config/),
 you should start by generating declarative config file.
 
 1. Generate a `kong.yml` file in your current folder using the following command:
@@ -74,4 +74,4 @@ Check out {{site.base_gateway}}'s series of
 [Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive) guides to get the most
 out of {{site.base_gateway}}.
 
-[configuration]: /gateway-oss/{{site.data.kong_latest.release}}/configuration/#database
+[configuration]: /gateway/{{include.kong_version}}/reference/configuration/#database

--- a/app/gateway/2.6.x/admin-api/event-hooks/examples.md
+++ b/app/gateway/2.6.x/admin-api/event-hooks/examples.md
@@ -3,7 +3,7 @@ title: Event Hooks Examples
 badge: enterprise
 ---
 
-{% include /md/enterprise/event-hooks-intro.md %}
+{% include_cached /md/enterprise/event-hooks-intro.md %}
 
 ## Webhook
 
@@ -151,7 +151,7 @@ config.payload.text={% raw %}"Admin account \`{{ entity.username }}\` {{ operati
 6. Turn on RBAC.
 
 {% capture anInclude %}
-{% include /md/enterprise/turn-on-rbac.md %}
+{% include_cached /md/enterprise/turn-on-rbac.md %}
 {% endcapture %}
 {{ anInclude | indent }}
 

--- a/app/gateway/2.6.x/admin-api/event-hooks/reference.md
+++ b/app/gateway/2.6.x/admin-api/event-hooks/reference.md
@@ -7,7 +7,7 @@ badge: enterprise
 > **Important:** Before you can use event hooks for the first time, Kong needs to be
 reloaded.
 
-{% include /md/enterprise/event-hooks-intro.md %}
+{% include_cached /md/enterprise/event-hooks-intro.md %}
 
 {:.note}
 > **Note:** Event hooks do not work with Konnect Cloud yet.

--- a/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
@@ -33,7 +33,7 @@ In the following sections, you will need the `kong_admin` account’s password t
 
 ## Turn on RBAC
 
-{% include /md/enterprise/turn-on-rbac.md %}
+{% include_cached /md/enterprise/turn-on-rbac.md %}
 
 ## Create a workspace
 

--- a/app/gateway/2.6.x/immunity/install-configure.md
+++ b/app/gateway/2.6.x/immunity/install-configure.md
@@ -5,7 +5,44 @@ badge: enterprise
 
 Kong Immunity (Immunity) is installed on {{site.base_gateway}}, either on Kubernetes or Docker, as defined below. Immunity uses the Collector App and Collector Plugin to communicate with {{site.base_gateway}}.
 
-{% include /md/enterprise/download/immunity.md version='>2.1' %}
+## Version Compatibility
+Immunity follows a different versioning scheme from {{site.base_gateway}}. The Immunity version reflects the `kong/immunity` package available on Docker Hub.
+For {{site.base_gateway}} 2.1.x and above, use Immunity 4.x.x.
+
+{:.warning}
+> **Warning:** Kong Immunity is not compatible with {{site.base_gateway}} v2.4.x.
+
+## Install Immunity on Kubernetes
+Set up the Collector App via Helm. Use the public helm chart for setting up the Collector App and all its dependencies on Kubernetes. Setup instructions can be found on the public repo at: [https://github.com/Kong/kong-collector-helm/blob/master/README.md](https://github.com/Kong/kong-collector-helm/blob/master/README.md).
+
+## Install Immunity on Docker
+Install Immunity by downloading, installing and starting the Collector App on Docker, as defined in this section. After installing the Collector App, you will enable the Collector Plugin to access Immunity on {{site.base_gateway}}.
+
+### Prerequisites
+To complete this installation you will need:
+
+* A Docker-enabled system with proper Docker access.
+
+* {{site.base_gateway}} 2.2.x or later is installed on Docker.
+
+* A valid [{{site.base_gateway}} License](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/access-license/) JSON file, including a license for Immunity.
+
+### Step 1. Pull the Immunity Docker image
+
+1. In a terminal window, pull the Kong Immunity Docker image.
+```bash
+$ docker pull kong/immunity:4.1.0
+```
+You should now have your Kong Immunity image locally.
+
+3. Verify that you have the Docker image. Find the image ID matching your repository:
+```bash
+$ docker images
+```
+4. Tag the image ID as `kong-immunity`. Replace `<IMAGE_ID>` with the image ID matching your repository.
+```bash
+$ docker tag <IMAGE_ID> kong-immunity
+```
 
 ### Step 2. Confirm the Kong EE Docker Network is available
 Confirm the {{site.base_gateway}} network is available, which is the network you set up when installing {{site.base_gateway}} on Docker named `kong-ee-net`.

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -64,4 +64,4 @@ Install the APT repository from the command line.
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/installation.md %}
+{% include_cached /md/installation.md kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/deploy-license.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/deploy-license.md
@@ -6,4 +6,4 @@ badge: enterprise
 Deploy an enterprise license to a {{site.base_gateway}} installation to gain access
 to [Enterprise-specific features](/gateway/{{page.kong_version}}/plan-and-deploy/licenses).
 
-{% include /md/enterprise/deploy-license.md heading="##" kong_version=page.kong_version %}
+{% include_cached /md/enterprise/deploy-license.md heading="##" kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/statsd.rules.yaml
+++ b/app/gateway/2.6.x/statsd.rules.yaml
@@ -1,0 +1,82 @@
+mappings:
+# by Service
+- match: kong.service.*.request.count
+  name: "kong_requests_proxy"
+  labels:
+    job: "kong_metrics"
+
+- match: kong.service.*.status.*
+  name: "kong_status_code"
+  labels:
+    service: "$1"
+    status_code: $2
+    job: "kong_metrics"
+
+- match: kong.service.*.kong_latency
+  name: "kong_latency_proxy_request"
+  timer_type: histogram
+  buckets: [1]
+  min_max: true
+  labels:
+    job: "kong_metrics"
+
+- match: kong.service.*.upstream_latency
+  name: "kong_latency_upstream"
+  timer_type: histogram
+  buckets: [1]
+  min_max: true
+  labels:
+    job: "kong_metrics"
+
+- match: kong.service.*.cache_datastore_hits_total
+  name: "kong_cache_datastore_hits_total"
+  labels:
+    job: "kong_metrics"
+
+- match: kong.service.*.cache_datastore_misses_total
+  name: "kong_cache_datastore_misses_total"
+  labels:
+    job: "kong_metrics"
+
+# by Service and Route
+- match: kong.service.*.user.*.status.*
+  name: "kong_status_code_per_consumer"
+  labels:
+    service: "$1"
+    route_id: ""
+    consumer: "$2"
+    status_code: $3
+    job: "kong_metrics"
+
+- match: kong.route.*.user.*.status.*
+  name: "kong_status_code_per_consumer"
+  labels:
+    service: ""
+    route_id: "$1"
+    consumer: "$2"
+    status_code: $3
+    job: "kong_metrics"
+
+# by Service and Workspace
+- match: kong.service.*.workspace.*.status.*
+  name: "kong_status_code_per_workspace"
+  labels:
+    service: "$1"
+    workspace: "$2"
+    status_code: $3
+    job: "kong_metrics"
+
+# by node
+- match: kong.node.*.shdict.*.free_space
+  name: "kong_shdict_free_space"
+  labels:
+    node: "$1"
+    shdict: "$2"
+    job: "kong_metrics"
+
+- match: kong.node.*.shdict.*.capacity
+  name: "kong_shdict_capacity"
+  labels:
+    node: "$1"
+    shdict: "$2"
+    job: "kong_metrics"


### PR DESCRIPTION
### Summary
* Updated links inside unversioned includes that are being used in /gateway/
* Fixed format of some includes that are being used in /gateway/
* Moved contents of Vitals and Immunity includes directly into their files; see reason section for explanation.
* Deleted 2.6.x deployment options includes, as they are no longer in use in that version.
* Moved statsd.rules.yaml into gateway folder, it was accidentally left out

### Reason
Original plan was to simply update links, however doing that would've changed them in other doc versions (they're used between versions).

Some includes are around simply to use between versions of the same topic; Immunity and Vitals were the two main culprits here. I moved the contents of those includes into their actual topics - using includes between versions is a neat idea but a maintenance nightmare in reality. It would also clash with our eventual plan of versioned branches.

### Testing
Tested locally.