### PR TITLE
Set wider version scope in jekyll config

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -134,7 +134,7 @@ defaults:
       layout: "docs-v2"
 
   - scope:
-      path: "gateway/2.6.x/install-and-run"
+      path: "gateway/2.6.x/"
     values:
       layout: "docs-v2"
       version-index: 0

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -135,7 +135,7 @@ defaults:
       layout: "docs-v2"
 
   - scope:
-      path: "gateway/2.6.x/install-and-run"
+      path: "gateway/2.6.x/"
     values:
       layout: "docs-v2"
       version-index: 0


### PR DESCRIPTION
### Summary
Widening the scope of the 2.6.x version to include the entire 2.6.x folder.

### Reason
Earlier, a version scope was added to the jekyll configuration file to pick up the specific version associated with the release - however, the scope was limited to just the `/install-and-run/` directory. Widening the scope so that we can use these new version variables in other places (for example, Vitals needs it as well).

### Testing
Tested locally, Vitals docs accurately pick up the required version.
