### PR TITLE
Fix smoke test specs

### DIFF
--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -1,9 +1,10 @@
 describe "breadcrumbs", type: :feature, js: true do
-  describe "Gateway OSS", type: :feature, js: true do
-    it "renders the index page breadcrumbs correctly" do
-      visit "/gateway-oss/"
-      expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("OPEN SOURCE")
-      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway (OSS)")
+  describe "Enterprise", type: :feature, js: true do
+    it "renders nested breadcrumbs correctly" do
+      visit "/enterprise/2.5.x/plugin-development/custom-entities/"
+      expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("KONG KONNECT PLATFORM")
+      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway")
+      expect(find(".breadcrumb-item:nth-of-type(3)").text).to eq("Plugin development")
     end
 
     it "renders nested breadcrumbs correctly" do
@@ -22,11 +23,11 @@ describe "breadcrumbs", type: :feature, js: true do
     end
   end
 
-  describe "Gateway Enterprise", type: :feature, js: true do
+  describe "Gateway", type: :feature, js: true do
     it "renders the index page breadcrumbs correctly" do
-      visit "/enterprise/"
+      visit "/gateway/"
       expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("KONG KONNECT PLATFORM")
-      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway (Enterprise)")
+      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway")
     end
   end
 end

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -25,17 +25,17 @@ describe "sidebar", type: :feature, js: true do
 
     it "does not show on the latest version" do
       visit "/gateway/#{latest_version}/install-and-run/rhel/"
-      expect(page).not_to have_selector(".alert.alert-warning a", visible: true)
+      expect(page).not_to have_selector(".important a", visible: true)
     end
 
     it "links to the same page" do
       visit "/deck/1.7.x/installation/"
-      expect(first('.alert.alert-warning a')[:href]).to end_with("/deck/#{latest_version_deck}/installation/")
+      expect(first('.important a')[:href]).to end_with("/deck/#{latest_version_deck}/installation/")
     end
 
     it "links to the root when the page no longer exists" do
       visit "/enterprise/0.31-x/postgresql-redhat/"
-      expect(first('.alert.alert-warning a')[:href]).to end_with("/gateway/")
+      expect(first('.important a')[:href]).to end_with("/gateway/")
     end
   end
 


### PR DESCRIPTION
### Summary
Adjust smoke tests to fit new URL and layout structure. 

### Reason
Smoke test failed: https://github.com/Kong/docs.konghq.com/runs/4195943254?check_suite_focus=true 

### Testing
Ran `make rspec` locally, passed with no errors.