### PR TITLE
[DOCU-1991] Handle latest split versions more gracefully

### DIFF
--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -96,12 +96,12 @@
         {% endfor %}
         {% if include.edition == 'gateway' %}
         <li role="menuitem" tabindex="-1">
-          <a href="/enterprise/">
+          <a href="/enterprise/2.5.x/">
             Older Enterprise versions
           </a>
         </li>
         <li role="menuitem" tabindex="-1">
-          <a href="/gateway-oss/">
+          <a href="/gateway-oss/2.5.x/">
             Older OSS versions
           </a>
         </li>

--- a/app/_plugins/versions.rb
+++ b/app/_plugins/versions.rb
@@ -56,23 +56,19 @@ module Jekyll
       site.data["kong_versions_contributing"] = contributingVersions
       site.data["kong_versions_gateway"] = gatewayVersions
 
-
       # Retrieve the latest version and put it in `site.data.kong_latest.version`
-      latestVersionCE = ceVersions.last
-      latestVersionEE = eeVersions.last
-      latestVersionGSG = gsgVersions.last
+
+      # There are no "latest" entries for ceVersions, eeVersions, or gsgVersions,
+      # because these docs no longer need a /latest/ URL. Any
+      # /enterprise/latest/, /gateway-oss/latest, or
+      # /getting-stared-guide/latest/ URL should redirect to /gateway/latest.
+
       latestVersionDeck = deckVersions.last
       latestVersionMesh = meshVersions.last
-      latestVersionKonnect = konnectVersions.last
-      latestVersionKonnectPlatform = konnectPlatformVersions.last
       latestVersionKIC = kicVersions.last
-      latestVersionContributing = contributingVersions.last
       latestVersionGateway = gatewayVersions.last
 
-      site.data["kong_latest"] = latestVersionCE
-      site.data["kong_latest_ee"] = latestVersionEE
       site.data["kong_latest_mesh"] = latestVersionMesh
-      site.data["kong_latest_gsg"] = latestVersionGSG
       site.data["kong_latest_KIC"] = latestVersionKIC
       site.data["kong_latest_deck"] = latestVersionDeck
       site.data["kong_latest_gateway"] = latestVersionGateway
@@ -88,16 +84,14 @@ module Jekyll
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
             page.data["kong_versions"] = eeVersions
-            page.data["kong_latest"] = latestVersionEE
             page.data["nav_items"] = site.data['docs_nav_ee_' + parts[1].gsub(/\./, '')]
-            createAliases(page, '/enterprise', 1, parts, latestVersionEE["release"])
+            createAliases(page, '/enterprise', 1, parts, "release" )
           elsif(parts[0] == 'getting-started-guide')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
             page.data["kong_versions"] = gsgVersions
-            page.data["kong_latest"] = latestVersionGSG
             page.data["nav_items"] = site.data['docs_nav_gsg_' + parts[1].gsub(/\./, '')]
-            createAliases(page, '/getting-started-guide', 1, parts, latestVersionGSG["release"])
+            createAliases(page, '/getting-started-guide', 1, parts, "release")
           elsif(parts[0] == 'mesh')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
@@ -109,16 +103,14 @@ module Jekyll
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
             page.data["kong_versions"] = konnectVersions
-            page.data["kong_latest"] = latestVersionKonnect
             page.data["nav_items"] = site.data['docs_nav_konnect']
-            createAliases(page, '/konnect', 1, parts, latestVersionKonnect["release"])
+            createAliases(page, '/konnect', 1, parts, "release")
           elsif(parts[0] == 'konnect-platform')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
             page.data["kong_versions"] = konnectPlatformVersions
-            page.data["kong_latest"] = latestVersionKonnectPlatform
             page.data["nav_items"] = site.data['docs_nav_konnect_platform']
-            createAliases(page, '/konnect-platform', 1, parts, latestVersionKonnectPlatform["release"])
+            createAliases(page, '/konnect-platform', 1, parts, "release")
           elsif(parts[0] == 'kubernetes-ingress-controller')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
@@ -144,16 +136,14 @@ module Jekyll
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
             page.data["kong_versions"] = contributingVersions
-            page.data["kong_latest"] = latestVersionContributing
             page.data["nav_items"] = site.data['docs_nav_contributing']
-            createAliases(page, '/contributing', 1, parts, latestVersionContributing["release"])
+            createAliases(page, '/contributing', 1, parts, "release")
           elsif(parts[0] == 'gateway-oss')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]
             page.data["kong_versions"] = ceVersions
-            page.data["kong_latest"] = latestVersionCE
             page.data["nav_items"] = site.data['docs_nav_ce_' + parts[1].gsub(/\./, '')]
-            createAliases(page, '/gateway-oss', 1, parts, latestVersionCE["release"])
+            createAliases(page, '/gateway-oss', 1, parts, "release")
           end
 
 

--- a/app/_redirects
+++ b/app/_redirects
@@ -42,12 +42,12 @@
 
 
 # GETTING STARTED GUIDES
-/enterprise/latest/getting-started/              /getting-started-guide/latest/overview/
+/enterprise/latest/getting-started/              /gateway/latest/get-started/comprehensive
 /enterprise/1.5.x/getting-started/               /getting-started-guide/ce-2.0.x_ke-1.5.x/overview/
 /gateway-oss/2.3.x/getting-started/introduction  /gateway-oss/2.3.x/
 /gateway-oss/2.4.x/getting-started/introduction  /gateway-oss/2.4.x/
-/gateway-oss/latest/getting-started/introduction /gateway-oss/
-/getting-started-guide/                          /getting-started-guide/latest/overview/
+/gateway-oss/latest/getting-started/introduction /gateway/latest/get-started/comprehensive
+/getting-started-guide/                          /gateway/latest/get-started/comprehensive
 /*/getting-started/enabling-plugins              /gateway/latest/get-started/quickstart/enabling-plugins
 /enterprise/0.34-x/getting-started/enabling-plugins/enterprise/0.34-x/plugins  /gateway/latest/get-started/quickstart/enabling-plugins
 /enterprise/1.5.x/getting-started/add-consumer   /gateway/latest/get-started/quickstart/adding-consumers
@@ -481,6 +481,11 @@
 
 
 # GENERAL REDIRECTS TO /GATEWAY/
+/enterprise/changelog      /gateway/changelog
+/enterprise/2.6.x/introduction/key-concepts     /konnect-platform/key-concepts
+/enterprise/latest/introduction/key-concepts    /konnect-platform/key-concepts
+/enterprise/2.6.x/introduction/support-policy   /konnect-platform/support-policy
+/enterprise/latest/introduction/support-policy  /konnect-platform/support-policy
 /latest/*                  /
 /latest                    /
 /2.6.x/*                   /gateway/2.6.x/
@@ -493,8 +498,6 @@
 /enterprise/latest/        /gateway/
 /gateway-oss/latest/       /gateway/
 /introduction              /
-/enterprise/changelog      /gateway/changelog
-/enterprise/2.6.x/introduction/key-concepts     /konnect-platform/key-concepts
-/enterprise/latest/introduction/key-concepts    /konnect-platform/key-concepts
-/enterprise/2.6.x/introduction/support-policy   /konnect-platform/support-policy
-/enterprise/latest/introduction/support-policy  /konnect-platform/support-policy
+/enterprise/               /gateway/
+/gateway-oss/              /gateway/
+/gateway-oss/


### PR DESCRIPTION
### Summary
Removing the functions that generate /latest/ URLs for `/enterprise/`, `/gateway-oss/`, and `/getting-started-guide/`. Redirects from /latest/ URLs should go to /gateway/ instead.

Also removing the same thing for `/konnect-platform/`, `/konnect/`, and `/contributing/`, as these docs don't have versions and we don't need to generate a "latest" version for them.

### Reason
Single-sourcing.

`/enterprise/`, `/gateway-oss/`, and `/getting-started-guide/` no longer have latest versions at these URLs. Their latest versions are located at `/gateway/`. We should not be generating these variables for something that doesn't exist.

### Testing
Tested locally. Also need to test in Netlify preview to make sure that /latest/ URLs go to the correct docs.