### PR TITLE
[DOCU-2021] Update links to /getting-started-guide/

### DIFF
--- a/app/_data/docs_nav_ce_2.0.x.yml
+++ b/app/_data/docs_nav_ce_2.0.x.yml
@@ -3,19 +3,19 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../getting-started-guide/latest/overview
+      url: /../../gateway/latest/get-started/comprehensive
     - text: Prepare to Administer
-      url: /../../getting-started-guide/latest/prepare
+      url: /../../gateway/latest/get-started/comprehensive/prepare
     - text: Expose your Services
-      url: /../../getting-started-guide/latest/expose-services
+      url: /../../gateway/latest/get-started/comprehensive/expose-services
     - text: Protect your Services
-      url: /../../getting-started-guide/latest/protect-services
+      url: /../../gateway/latest/get-started/comprehensive/protect-services
     - text: Improve Performance
-      url: /../../getting-started-guide/latest/improve-performance
+      url: /../../gateway/latest/get-started/comprehensive/improve-performance
     - text: Secure Services
-      url: /../../getting-started-guide/latest/secure-services
+      url: /../../gateway/latest/get-started/comprehensive/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../getting-started-guide/latest/load-balancing
+      url: /../../gateway/latest/get-started/comprehensive/load-balancing
 
 - title: Guides &amp; References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ce_2.1.x.yml
+++ b/app/_data/docs_nav_ce_2.1.x.yml
@@ -3,19 +3,19 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../getting-started-guide/latest/overview
+      url: /../../gateway/latest/get-started/comprehensive
     - text: Prepare to Administer
-      url: /../../getting-started-guide/latest/prepare
+      url: /../../gateway/latest/get-started/comprehensive/prepare
     - text: Expose your Services
-      url: /../../getting-started-guide/latest/expose-services
+      url: /../../gateway/latest/get-started/comprehensive/expose-services
     - text: Protect your Services
-      url: /../../getting-started-guide/latest/protect-services
+      url: /../../gateway/latest/get-started/comprehensive/protect-services
     - text: Improve Performance
-      url: /../../getting-started-guide/latest/improve-performance
+      url: /../../gateway/latest/get-started/comprehensive/improve-performance
     - text: Secure Services
-      url: /../../getting-started-guide/latest/secure-services
+      url: /../../gateway/latest/get-started/comprehensive/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../getting-started-guide/latest/load-balancing
+      url: /../../gateway/latest/get-started/comprehensive/load-balancing
 
 - title: Guides &amp; References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ce_2.2.x.yml
+++ b/app/_data/docs_nav_ce_2.2.x.yml
@@ -3,19 +3,19 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../getting-started-guide/latest/overview
+      url: /../../gateway/latest/get-started/comprehensive
     - text: Prepare to Administer
-      url: /../../getting-started-guide/latest/prepare
+      url: /../../gateway/latest/get-started/comprehensive/prepare
     - text: Expose your Services
-      url: /../../getting-started-guide/latest/expose-services
+      url: /../../gateway/latest/get-started/comprehensive/expose-services
     - text: Protect your Services
-      url: /../../getting-started-guide/latest/protect-services
+      url: /../../gateway/latest/get-started/comprehensive/protect-services
     - text: Improve Performance
-      url: /../../getting-started-guide/latest/improve-performance
+      url: /../../gateway/latest/get-started/comprehensive/improve-performance
     - text: Secure Services
-      url: /../../getting-started-guide/latest/secure-services
+      url: /../../gateway/latest/get-started/comprehensive/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../getting-started-guide/latest/load-balancing
+      url: /../../gateway/latest/get-started/comprehensive/load-balancing
 
 - title: Guides &amp; References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ce_2.3.x.yml
+++ b/app/_data/docs_nav_ce_2.3.x.yml
@@ -32,31 +32,31 @@
     - text: Getting Started Guide
       items:
         - text: Overview
-          url: /getting-started-guide/latest/overview
+          url: /gateway/latest/get-started/comprehensive
           absolute_url: true
           target_blank: true
         - text: Prepare to Administer
-          url: /getting-started-guide/latest/prepare
+          url: /gateway/latest/get-started/comprehensive/prepare
           absolute_url: true
           target_blank: true
         - text: Expose your Services
-          url: /getting-started-guide/latest/expose-services
+          url: /gateway/latest/get-started/comprehensive/expose-services
           absolute_url: true
           target_blank: true
         - text: Protect your Services
-          url: /getting-started-guide/latest/protect-services
+          url: /gateway/latest/get-started/comprehensive/protect-services
           absolute_url: true
           target_blank: true
         - text: Improve Performance
-          url: /getting-started-guide/latest/improve-performance
+          url: /gateway/latest/get-started/comprehensive/improve-performance
           absolute_url: true
           target_blank: true
         - text: Secure Services
-          url: /getting-started-guide/latest/secure-services
+          url: /gateway/latest/get-started/comprehensive/secure-services
           absolute_url: true
           target_blank: true
         - text: Set Up Intelligent Load Balancing
-          url: /getting-started-guide/latest/load-balancing
+          url: /gateway/latest/get-started/comprehensive/load-balancing
           absolute_url: true
 
 - title: Guides &amp; References

--- a/app/_data/docs_nav_ce_2.4.x.yml
+++ b/app/_data/docs_nav_ce_2.4.x.yml
@@ -32,31 +32,31 @@
     - text: Getting Started Guide
       items:
         - text: Overview
-          url: /getting-started-guide/latest/overview
+          url: /gateway/latest/get-started/comprehensive
           absolute_url: true
           target_blank: true
         - text: Prepare to Administer
-          url: /getting-started-guide/latest/prepare
+          url: /gateway/latest/get-started/comprehensive/prepare
           absolute_url: true
           target_blank: true
         - text: Expose your Services
-          url: /getting-started-guide/latest/expose-services
+          url: /gateway/latest/get-started/comprehensive/expose-services
           absolute_url: true
           target_blank: true
         - text: Protect your Services
-          url: /getting-started-guide/latest/protect-services
+          url: /gateway/latest/get-started/comprehensive/protect-services
           absolute_url: true
           target_blank: true
         - text: Improve Performance
-          url: /getting-started-guide/latest/improve-performance
+          url: /gateway/latest/get-started/comprehensive/improve-performance
           absolute_url: true
           target_blank: true
         - text: Secure Services
-          url: /getting-started-guide/latest/secure-services
+          url: /gateway/latest/get-started/comprehensive/secure-services
           absolute_url: true
           target_blank: true
         - text: Set Up Intelligent Load Balancing
-          url: /getting-started-guide/latest/load-balancing
+          url: /gateway/latest/get-started/comprehensive/load-balancing
           absolute_url: true
 
 - title: Guides &amp; References

--- a/app/_data/docs_nav_ce_2.5.x.yml
+++ b/app/_data/docs_nav_ce_2.5.x.yml
@@ -32,31 +32,31 @@
     - text: Getting Started Guide
       items:
         - text: Overview
-          url: /getting-started-guide/latest/overview
+          url: /gateway/latest/get-started/comprehensive
           absolute_url: true
           target_blank: true
         - text: Prepare to Administer
-          url: /getting-started-guide/latest/prepare
+          url: /gateway/latest/get-started/comprehensive/prepare
           absolute_url: true
           target_blank: true
         - text: Expose your Services
-          url: /getting-started-guide/latest/expose-services
+          url: /gateway/latest/get-started/comprehensive/expose-services
           absolute_url: true
           target_blank: true
         - text: Protect your Services
-          url: /getting-started-guide/latest/protect-services
+          url: /gateway/latest/get-started/comprehensive/protect-services
           absolute_url: true
           target_blank: true
         - text: Improve Performance
-          url: /getting-started-guide/latest/improve-performance
+          url: /gateway/latest/get-started/comprehensive/improve-performance
           absolute_url: true
           target_blank: true
         - text: Secure Services
-          url: /getting-started-guide/latest/secure-services
+          url: /gateway/latest/get-started/comprehensive/secure-services
           absolute_url: true
           target_blank: true
         - text: Set Up Intelligent Load Balancing
-          url: /getting-started-guide/latest/load-balancing
+          url: /gateway/latest/get-started/comprehensive/load-balancing
           absolute_url: true
 
 - title: Guides &amp; References

--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -83,23 +83,23 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../getting-started-guide/latest/overview
+      url: /../../gateway/latest/get-started/comprehensive
     - text: Prepare to Administer
-      url: /../../getting-started-guide/latest/prepare
+      url: /../../gateway/latest/get-started/comprehensive/prepare
     - text: Expose your Services
-      url: /../../getting-started-guide/latest/expose-services
+      url: /../../gateway/latest/get-started/comprehensive/expose-services
     - text: Protect your Services
-      url: /../../getting-started-guide/latest/protect-services
+      url: /../../gateway/latest/get-started/comprehensive/protect-services
     - text: Improve Performance
-      url: /../../getting-started-guide/latest/improve-performance
+      url: /../../gateway/latest/get-started/comprehensive/improve-performance
     - text: Secure Services
-      url: /../../getting-started-guide/latest/secure-services
+      url: /../../gateway/latest/get-started/comprehensive/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../getting-started-guide/latest/load-balancing
+      url: /../../gateway/latest/get-started/comprehensive/load-balancing
     - text: Manage Administrative Teams
-      url: /../../getting-started-guide/latest/manage-teams
+      url: /../../gateway/latest/get-started/comprehensive/manage-teams
     - text: Publish, Locate, and Consume Services
-      url: /../../getting-started-guide/latest/dev-portal
+      url: /../../gateway/latest/get-started/comprehensive/dev-portal
 
 - title: Guides & References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -136,23 +136,23 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../getting-started-guide/latest/overview
+      url: /../../gateway/latest/get-started/comprehensive
     - text: Prepare to Administer
-      url: /../../getting-started-guide/latest/prepare
+      url: /../../gateway/latest/get-started/comprehensive/prepare
     - text: Expose your Services
-      url: /../../getting-started-guide/latest/expose-services
+      url: /../../gateway/latest/get-started/comprehensive/expose-services
     - text: Protect your Services
-      url: /../../getting-started-guide/latest/protect-services
+      url: /../../gateway/latest/get-started/comprehensive/protect-services
     - text: Improve Performance
-      url: /../../getting-started-guide/latest/improve-performance
+      url: /../../gateway/latest/get-started/comprehensive/improve-performance
     - text: Secure Services
-      url: /../../getting-started-guide/latest/secure-services
+      url: /../../gateway/latest/get-started/comprehensive/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../getting-started-guide/latest/load-balancing
+      url: /../../gateway/latest/get-started/comprehensive/load-balancing
     - text: Manage Administrative Teams
-      url: /../../getting-started-guide/latest/manage-teams
+      url: /../../gateway/latest/get-started/comprehensive/manage-teams
     - text: Publish, Locate, and Consume Services
-      url: /../../getting-started-guide/latest/dev-portal
+      url: /../../gateway/latest/get-started/comprehensive/dev-portal
 
 - title: Guides & References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -131,23 +131,23 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../getting-started-guide/latest/overview
+      url: /../../gateway/latest/get-started/comprehensive
     - text: Prepare to Administer
-      url: /../../getting-started-guide/latest/prepare
+      url: /../../gateway/latest/get-started/comprehensive/prepare
     - text: Expose your Services
-      url: /../../getting-started-guide/latest/expose-services
+      url: /../../gateway/latest/get-started/comprehensive/expose-services
     - text: Protect your Services
-      url: /../../getting-started-guide/latest/protect-services
+      url: /../../gateway/latest/get-started/comprehensive/protect-services
     - text: Improve Performance
-      url: /../../getting-started-guide/latest/improve-performance
+      url: /../../gateway/latest/get-started/comprehensive/improve-performance
     - text: Secure Services
-      url: /../../getting-started-guide/latest/secure-services
+      url: /../../gateway/latest/get-started/comprehensive/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../getting-started-guide/latest/load-balancing
+      url: /../../gateway/latest/get-started/comprehensive/load-balancing
     - text: Manage Administrative Teams
-      url: /../../getting-started-guide/latest/manage-teams
+      url: /../../gateway/latest/get-started/comprehensive/manage-teams
     - text: Publish, Locate, and Consume Services
-      url: /../../getting-started-guide/latest/dev-portal
+      url: /../../gateway/latest/get-started/comprehensive/dev-portal
 
 - title: Guides & References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -136,40 +136,40 @@
 
 - title: Getting Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
-  url: /getting-started-guide/latest/overview
+  url: /gateway/latest/get-started/comprehensive
   absolute_url: true
   target_blank: true
   items:
     - text: Prepare to Administer
-      url: /getting-started-guide/latest/prepare
+      url: /gateway/latest/get-started/comprehensive/prepare
       absolute_url: true
       target_blank: true
     - text: Expose your Services
-      url: /getting-started-guide/latest/expose-services
+      url: /gateway/latest/get-started/comprehensive/expose-services
       absolute_url: true
       target_blank: true
     - text: Protect your Services
-      url: /getting-started-guide/latest/protect-services
+      url: /gateway/latest/get-started/comprehensive/protect-services
       absolute_url: true
       target_blank: true
     - text: Improve Performance
-      url: /getting-started-guide/latest/improve-performance
+      url: /gateway/latest/get-started/comprehensive/improve-performance
       absolute_url: true
       target_blank: true
     - text: Secure Services
-      url: /getting-started-guide/latest/secure-services
+      url: /gateway/latest/get-started/comprehensive/secure-services
       absolute_url: true
       target_blank: true
     - text: Set Up Intelligent Load Balancing
-      url: /getting-started-guide/latest/load-balancing
+      url: /gateway/latest/get-started/comprehensive/load-balancing
       absolute_url: true
       target_blank: true
     - text: Manage Administrative Teams
-      url: /getting-started-guide/latest/manage-teams
+      url: /gateway/latest/get-started/comprehensive/manage-teams
       absolute_url: true
       target_blank: true
     - text: Publish, Locate, and Consume Services
-      url: /getting-started-guide/latest/dev-portal
+      url: /gateway/latest/get-started/comprehensive/dev-portal
       absolute_url: true
       target_blank: true
 

--- a/app/_data/docs_nav_ee_2.4.x.yml
+++ b/app/_data/docs_nav_ee_2.4.x.yml
@@ -135,40 +135,40 @@
 
 - title: Getting Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
-  url: /getting-started-guide/latest/overview
+  url: /gateway/latest/get-started/comprehensive
   absolute_url: true
   target_blank: true
   items:
     - text: Prepare to Administer
-      url: /getting-started-guide/latest/prepare
+      url: /gateway/latest/get-started/comprehensive/prepare
       absolute_url: true
       target_blank: true
     - text: Expose your Services
-      url: /getting-started-guide/latest/expose-services
+      url: /gateway/latest/get-started/comprehensive/expose-services
       absolute_url: true
       target_blank: true
     - text: Protect your Services
-      url: /getting-started-guide/latest/protect-services
+      url: /gateway/latest/get-started/comprehensive/protect-services
       absolute_url: true
       target_blank: true
     - text: Improve Performance
-      url: /getting-started-guide/latest/improve-performance
+      url: /gateway/latest/get-started/comprehensive/improve-performance
       absolute_url: true
       target_blank: true
     - text: Secure Services
-      url: /getting-started-guide/latest/secure-services
+      url: /gateway/latest/get-started/comprehensive/secure-services
       absolute_url: true
       target_blank: true
     - text: Set Up Intelligent Load Balancing
-      url: /getting-started-guide/latest/load-balancing
+      url: /gateway/latest/get-started/comprehensive/load-balancing
       absolute_url: true
       target_blank: true
     - text: Manage Administrative Teams
-      url: /getting-started-guide/latest/manage-teams
+      url: /gateway/latest/get-started/comprehensive/manage-teams
       absolute_url: true
       target_blank: true
     - text: Publish, Locate, and Consume Services
-      url: /getting-started-guide/latest/dev-portal
+      url: /gateway/latest/get-started/comprehensive/dev-portal
       absolute_url: true
       target_blank: true
 

--- a/app/_data/docs_nav_ee_2.5.x.yml
+++ b/app/_data/docs_nav_ee_2.5.x.yml
@@ -131,40 +131,40 @@
 
 - title: Getting Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
-  url: /getting-started-guide/latest/overview
+  url: /gateway/latest/get-started/comprehensive
   absolute_url: true
   target_blank: true
   items:
     - text: Prepare to Administer
-      url: /getting-started-guide/latest/prepare
+      url: /gateway/latest/get-started/comprehensive/prepare
       absolute_url: true
       target_blank: true
     - text: Expose your Services
-      url: /getting-started-guide/latest/expose-services
+      url: /gateway/latest/get-started/comprehensive/expose-services
       absolute_url: true
       target_blank: true
     - text: Protect your Services
-      url: /getting-started-guide/latest/protect-services
+      url: /gateway/latest/get-started/comprehensive/protect-services
       absolute_url: true
       target_blank: true
     - text: Improve Performance
-      url: /getting-started-guide/latest/improve-performance
+      url: /gateway/latest/get-started/comprehensive/improve-performance
       absolute_url: true
       target_blank: true
     - text: Secure Services
-      url: /getting-started-guide/latest/secure-services
+      url: /gateway/latest/get-started/comprehensive/secure-services
       absolute_url: true
       target_blank: true
     - text: Set Up Intelligent Load Balancing
-      url: /getting-started-guide/latest/load-balancing
+      url: /gateway/latest/get-started/comprehensive/load-balancing
       absolute_url: true
       target_blank: true
     - text: Manage Administrative Teams
-      url: /getting-started-guide/latest/manage-teams
+      url: /gateway/latest/get-started/comprehensive/manage-teams
       absolute_url: true
       target_blank: true
     - text: Publish, Locate, and Consume Services
-      url: /getting-started-guide/latest/dev-portal
+      url: /gateway/latest/get-started/comprehensive/dev-portal
       absolute_url: true
       target_blank: true
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -98,8 +98,8 @@ the nav file would be `/overview`, and you would add it to the file
 
 ### Add redirects
 
-If you're making an organization change like updating page nesting or renaming a top-level 
-menu item, you'll need to set up a redirect. Redirects prevent `404` pages, and 
+If you're making an organization change like updating page nesting or renaming a top-level
+menu item, you'll need to set up a redirect. Redirects prevent `404` pages, and
 redirect users automatically to the new content location.
 
 1. Navigate to `app` then `_redirects`.
@@ -110,9 +110,9 @@ redirect users automatically to the new content location.
 ```bash
 \\ Start the link with what appears after https://docs.konghq.com/.
 
-\\ In the following example, we created a new menu section called Applications 
+\\ In the following example, we created a new menu section called Applications
 in the Dev Portal section of the docs. And we moved the dev-apps page to our
-new menu section. 
+new menu section.
 
 /konnect/dev-portal/developers/dev-apps                    /konnect/dev-portal/applications/dev-apps
 ```
@@ -224,7 +224,7 @@ port: 80 </code></pre></div>
 
 If your topic provides instructions for two or more methods of completing a
 task, you can nest them inside `navtabs`. For example,
-[this topic](https://docs.konghq.com/getting-started-guide/latest/expose-services/#add-a-service)
+[this topic](https://docs.konghq.com/gateway/latest/get-started/comprehensive/expose-services/#add-a-service)
 tabs between the Admin API and Kong Manager methods for adding a Service.
 
 {:.important}

--- a/app/enterprise/1.5.x/index.md
+++ b/app/enterprise/1.5.x/index.md
@@ -21,9 +21,9 @@ is_homepage: true
   </div>
 
   <div class="docs-grid-block">
-    <h3><a href="/getting-started-guide/latest/overview">Getting Started</a></h3>
+    <h3><a href="/gateway/latest/get-started/comprehensive/">Getting Started</a></h3>
     <p>Whether you’re a Community or an Enterprise Kong user, use this guide to familiarize yourself with Kong concepts and learn how to use important features and capabilities.</p>
-    <a href="/getting-started-guide/latest/overview">Get Started &rarr;</a>
+    <a href="/gateway/latest/get-started/comprehensive/">Get Started &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/enterprise/1.5.x/release-notes.md
+++ b/app/enterprise/1.5.x/release-notes.md
@@ -34,7 +34,7 @@ Apart from the highlighted features mentioned above, this version of Kong Enterp
 
 In addition to features listed above, changes to the user documentation include:
 
-* [Getting Started Guide](https://docs.konghq.com/getting-started-guide/latest/overview/) walks you through Kong concepts and foundational API gateway features and capabilities.
+* [Getting Started Guide](https://docs.konghq.com/gateway/latest/get-started/comprehensive//) walks you through Kong concepts and foundational API gateway features and capabilities.
 * [Introduction to Kong Enterprise](https://docs.konghq.com/enterprise/1.5.x/introduction/) gives an overview of features and architecture. 
 * [Key Concepts and Terminology](https://docs.konghq.com/enterprise/1.5.x/introduction/key-concepts/) defines concepts and terms specific to Kong Enterprise.
 * [Default Ports](https://docs.konghq.com/enterprise/1.5.x/deployment/default-ports/) list. 

--- a/app/enterprise/2.1.x/admin-api/rbac/examples.md
+++ b/app/enterprise/2.1.x/admin-api/rbac/examples.md
@@ -1045,4 +1045,4 @@ he created.
 [rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
 [rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
 [workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
-[getting-started-guide]: /getting-started-guide/latest/overview
+[getting-started-guide]: /gateway/latest/get-started/comprehensive/

--- a/app/enterprise/2.1.x/index.md
+++ b/app/enterprise/2.1.x/index.md
@@ -21,9 +21,9 @@ is_homepage: true
   </div>
 
   <div class="docs-grid-block">
-    <h3><a href="/getting-started-guide/latest/overview">Getting Started</a></h3>
+    <h3><a href="/gateway/latest/get-started/comprehensive/">Getting Started</a></h3>
     <p>Whether you’re a Community or an Enterprise Kong user, use this guide to familiarize yourself with Kong concepts and learn how to use important features and capabilities.</p>
-    <a href="/getting-started-guide/latest/overview">Get Started &rarr;</a>
+    <a href="/gateway/latest/get-started/comprehensive/">Get Started &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/enterprise/2.2.x/admin-api/rbac/examples.md
+++ b/app/enterprise/2.2.x/admin-api/rbac/examples.md
@@ -1045,4 +1045,4 @@ he created.
 [rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
 [rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
 [workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
-[getting-started-guide]: /getting-started-guide/latest/overview
+[getting-started-guide]: /gateway/latest/get-started/comprehensive/

--- a/app/enterprise/2.2.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.2.x/deployment/installation/amazon-linux-2.md
@@ -253,5 +253,5 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.

--- a/app/enterprise/2.2.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.2.x/deployment/installation/amazon-linux.md
@@ -263,5 +263,5 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.

--- a/app/enterprise/2.2.x/deployment/installation/centos.md
+++ b/app/enterprise/2.2.x/deployment/installation/centos.md
@@ -279,5 +279,5 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.

--- a/app/enterprise/2.2.x/deployment/installation/docker.md
+++ b/app/enterprise/2.2.x/deployment/installation/docker.md
@@ -177,5 +177,5 @@ setup, reach out to your **Support contact** or head over to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.

--- a/app/enterprise/2.2.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.2.x/deployment/installation/rhel.md
@@ -278,5 +278,5 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.

--- a/app/enterprise/2.2.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.2.x/deployment/installation/ubuntu.md
@@ -229,5 +229,5 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.

--- a/app/enterprise/2.2.x/index.md
+++ b/app/enterprise/2.2.x/index.md
@@ -21,9 +21,9 @@ is_homepage: true
   </div>
 
   <div class="docs-grid-block">
-    <h3><a href="/getting-started-guide/latest/overview">Getting Started</a></h3>
+    <h3><a href="/gateway/latest/get-started/comprehensive/">Getting Started</a></h3>
     <p>Whether you’re an open-source or {{site.konnect_product_name}} user, use this guide to familiarize yourself with {{site.base_gateway}} concepts and learn how to use important features and capabilities.</p>
-    <a href="/getting-started-guide/latest/overview">Get Started &rarr;</a>
+    <a href="/gateway/latest/get-started/comprehensive/">Get Started &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/enterprise/2.3.x/admin-api/rbac/examples.md
+++ b/app/enterprise/2.3.x/admin-api/rbac/examples.md
@@ -1045,4 +1045,4 @@ he created.
 [rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
 [rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
 [workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
-[getting-started-guide]: /getting-started-guide/latest/overview
+[getting-started-guide]: /gateway/latest/get-started/comprehensive/

--- a/app/enterprise/2.3.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.3.x/deployment/installation/amazon-linux-2.md
@@ -258,7 +258,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.3.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.3.x/deployment/installation/amazon-linux.md
@@ -259,7 +259,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.3.x/deployment/installation/centos.md
+++ b/app/enterprise/2.3.x/deployment/installation/centos.md
@@ -277,7 +277,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -190,7 +190,7 @@ setup, reach out to your **Support contact** or head over to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.3.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.3.x/deployment/installation/rhel.md
@@ -275,7 +275,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.3.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.3.x/deployment/installation/ubuntu.md
@@ -225,7 +225,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.4.x/admin-api/rbac/examples.md
+++ b/app/enterprise/2.4.x/admin-api/rbac/examples.md
@@ -1045,4 +1045,4 @@ he created.
 [rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
 [rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
 [workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
-[getting-started-guide]: /getting-started-guide/latest/overview
+[getting-started-guide]: /gateway/latest/get-started/comprehensive/

--- a/app/enterprise/2.4.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.4.x/deployment/installation/amazon-linux-2.md
@@ -259,7 +259,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.4.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.4.x/deployment/installation/amazon-linux.md
@@ -259,7 +259,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.4.x/deployment/installation/centos.md
+++ b/app/enterprise/2.4.x/deployment/installation/centos.md
@@ -277,7 +277,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.4.x/deployment/installation/docker.md
+++ b/app/enterprise/2.4.x/deployment/installation/docker.md
@@ -101,7 +101,7 @@ setup, reach out to your **Support contact** or head over to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.4.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.4.x/deployment/installation/rhel.md
@@ -275,7 +275,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.4.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.4.x/deployment/installation/ubuntu.md
@@ -224,7 +224,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.5.x/admin-api/rbac/examples.md
+++ b/app/enterprise/2.5.x/admin-api/rbac/examples.md
@@ -1045,4 +1045,4 @@ he created.
 [rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
 [rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
 [workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
-[getting-started-guide]: /getting-started-guide/latest/overview
+[getting-started-guide]: /gateway/latest/get-started/comprehensive/

--- a/app/enterprise/2.5.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.5.x/deployment/installation/amazon-linux-2.md
@@ -259,7 +259,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.5.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.5.x/deployment/installation/amazon-linux.md
@@ -260,7 +260,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.5.x/deployment/installation/centos.md
+++ b/app/enterprise/2.5.x/deployment/installation/centos.md
@@ -256,7 +256,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.5.x/deployment/installation/docker.md
+++ b/app/enterprise/2.5.x/deployment/installation/docker.md
@@ -101,7 +101,7 @@ setup, reach out to your **Support contact** or head over to the
 ## Next Steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.5.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.5.x/deployment/installation/rhel.md
@@ -275,7 +275,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/enterprise/2.5.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.5.x/deployment/installation/ubuntu.md
@@ -225,7 +225,7 @@ your setup, reach out to your Kong Support contact or go to the
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/getting-started-guide/latest/overview) guides to get the most
+[Getting Started](/gateway/latest/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the

--- a/app/gateway-oss/2.0.x/index.md
+++ b/app/gateway-oss/2.0.x/index.md
@@ -11,9 +11,9 @@ is_homepage: true
   </div>
 
   <div class="docs-grid-block">
-    <h3><a href="/getting-started-guide/latest/overview">Getting Started</a></h3>
+    <h3><a href="/gateway/latest/get-started/comprehensive/">Getting Started</a></h3>
     <p>Whether you’re a Community or an Enterprise Kong user, use this guide to familiarize yourself with Kong concepts and learn how to use important features and capabilities.</p>
-    <a href="/getting-started-guide/latest/overview">Get started &rarr;</a>
+    <a href="/gateway/latest/get-started/comprehensive/">Get started &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.1.x/index.md
+++ b/app/gateway-oss/2.1.x/index.md
@@ -11,9 +11,9 @@ is_homepage: true
   </div>
 
   <div class="docs-grid-block">
-    <h3><a href="/getting-started-guide/latest/overview">Getting Started</a></h3>
+    <h3><a href="/gateway/latest/get-started/comprehensive/">Getting Started</a></h3>
     <p>Whether you’re a Community or an Enterprise Kong user, use this guide to familiarize yourself with Kong concepts and learn how to use important features and capabilities.</p>
-    <a href="/getting-started-guide/latest/overview">Get started &rarr;</a>
+    <a href="/gateway/latest/get-started/comprehensive/">Get started &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.2.x/index.md
+++ b/app/gateway-oss/2.2.x/index.md
@@ -11,11 +11,11 @@ is_homepage: true
   </div>
 
   <div class="docs-grid-block">
-    <h3><a href="/getting-started-guide/latest/overview">Getting Started</a></h3>
+    <h3><a href="/gateway/latest/get-started/comprehensive/">Getting Started</a></h3>
     <p>Whether you’re an open-source or a {{site.konnect_product_name}}
     user, use this guide to familiarize yourself with API gateway concepts and
     learn how to use important features and capabilities.</p>
-    <a href="/getting-started-guide/latest/overview">Get started &rarr;</a>
+    <a href="/gateway/latest/get-started/comprehensive/">Get started &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.3.x/index.md
+++ b/app/gateway-oss/2.3.x/index.md
@@ -25,4 +25,4 @@ Kong's many available tools for managing the gateway.
 [quickstart]: /{{page.kong_version}}/getting-started/quickstart
 [configuring-a-service]: /{{page.kong_version}}/getting-started/configuring-a-service
 [enabling-plugins]: /{{page.kong_version}}/getting-started/enabling-plugins
-[getting-started]: /getting-started-guide/latest/overview
+[getting-started]: /gateway/latest/get-started/comprehensive/

--- a/app/gateway-oss/2.4.x/index.md
+++ b/app/gateway-oss/2.4.x/index.md
@@ -25,4 +25,4 @@ Kong's many available tools for managing the gateway.
 [quickstart]: /gateway-oss/{{page.kong_version}}/getting-started/quickstart
 [configuring-a-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service
 [enabling-plugins]: /gateway-oss/{{page.kong_version}}/getting-started/enabling-plugins
-[getting-started]: /getting-started-guide/latest/overview
+[getting-started]: /gateway/latest/get-started/comprehensive/

--- a/app/gateway-oss/2.5.x/index.md
+++ b/app/gateway-oss/2.5.x/index.md
@@ -25,4 +25,4 @@ Kong's many available tools for managing the gateway.
 [quickstart]: /gateway-oss/{{page.kong_version}}/getting-started/quickstart
 [configuring-a-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service
 [enabling-plugins]: /gateway-oss/{{page.kong_version}}/getting-started/enabling-plugins
-[getting-started]: /getting-started-guide/latest/overview
+[getting-started]: /gateway/latest/get-started/comprehensive/


### PR DESCRIPTION
### Summary
Summary
Updating `/latest/` links to point to `/gateway/` instead of `/getting-started-guide/`

### Reason
Single-sourcing.

### Testing
Tested locally.
