### PR TITLE
[DOCU-2028] Change RBAC labels from free to enterprise

### DIFF
--- a/app/gateway/2.6.x/admin-api/admins/examples.md
+++ b/app/gateway/2.6.x/admin-api/admins/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Admins Examples
-badge: free
+badge: enterprise
 ---
 
 ## How to Invite and Register an Admin

--- a/app/gateway/2.6.x/admin-api/admins/reference.md
+++ b/app/gateway/2.6.x/admin-api/admins/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Admins Reference
-badge: free
+badge: enterprise
 ---
 
 ## List Admins

--- a/app/gateway/2.6.x/admin-api/rbac/examples.md
+++ b/app/gateway/2.6.x/admin-api/rbac/examples.md
@@ -1,6 +1,6 @@
 ---
 title: RBAC Examples
-badge: free
+badge: enterprise
 ---
 
 This chapter aims to provide a step-by-step tutorial on how to set up

--- a/app/gateway/2.6.x/admin-api/rbac/reference.md
+++ b/app/gateway/2.6.x/admin-api/rbac/reference.md
@@ -1,6 +1,6 @@
 ---
 title: RBAC Reference
-badge: free
+badge: enterprise
 ---
 
 Kong {{site.base_gateway}}'s RBAC feature is configurable through Kong's

--- a/app/gateway/2.6.x/admin-api/secure-admin-api.md
+++ b/app/gateway/2.6.x/admin-api/secure-admin-api.md
@@ -228,7 +228,7 @@ For more information on integrating Kong into custom Nginx configurations, see
 [Custom Nginx configuration & embedding Kong][custom-configuration].
 
 ## Role Based Access Control
-{:.badge .free}
+{:.badge .enterprise}
 
 {{site.base_gateway}} users can configure [role-based access control](/gateway/{{page.kong_version}}/configure/auth/rbac)
 to secure access to the Admin API. RBAC allows for fine-grained control over resource access

--- a/app/gateway/2.6.x/admin-api/workspaces/examples.md
+++ b/app/gateway/2.6.x/admin-api/workspaces/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Workspace Examples
-badge: free
+badge: enterprise
 ---
 
 This chapter aims to provide a step-by-step tutorial on how to set up

--- a/app/gateway/2.6.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.6.x/admin-api/workspaces/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Workspaces Reference
-badge: free
+badge: enterprise
 
 workspace_body: |
     Attribute | Description

--- a/app/gateway/2.6.x/configure/auth/kong-manager/basic.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/basic.md
@@ -1,6 +1,6 @@
 ---
 title: Enable Basic Auth for Kong Manager
-badge: free
+badge: enterprise
 ---
 
 ### Prerequisites

--- a/app/gateway/2.6.x/configure/auth/kong-manager/email.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/email.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Kong Manager to Send Email
-badge: free
+badge: enterprise
 ---
 
 A **Super Admin** can invite other **Admins** to register in Kong Manager, and **Admins**

--- a/app/gateway/2.6.x/configure/auth/kong-manager/index.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/index.md
@@ -1,6 +1,6 @@
 ---
 title: Securing Kong Manager
-badge: free
+badge: enterprise
 ---
 
 Kong Manager enables users with Admin accounts to access Kong entities such

--- a/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
@@ -1,6 +1,6 @@
 ---
 title: Default and Custom Networking Configuration for Kong Manager
-badge: free
+badge: enterprise
 ---
 
 ## Default Configuration

--- a/app/gateway/2.6.x/configure/auth/kong-manager/reset-password.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/reset-password.md
@@ -1,6 +1,6 @@
 ---
 title: Reset Passwords and RBAC Tokens in Kong Manager
-badge: free
+badge: enterprise
 ---
 
 ## Passwords and RBAC Tokens

--- a/app/gateway/2.6.x/configure/auth/kong-manager/sessions.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/sessions.md
@@ -1,6 +1,6 @@
 ---
 title: Sessions in Kong Manager
-badge: free
+badge: enterprise
 ---
 
 ## How does the Sessions Plugin work in Kong Manager?

--- a/app/gateway/2.6.x/configure/auth/kong-manager/super-admin.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/super-admin.md
@@ -1,6 +1,6 @@
 ---
 title: Create a Super Admin
-badge: free
+badge: enterprise
 ---
 
 If you seeded a **Super Admin** at the time of running

--- a/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
@@ -1,6 +1,6 @@
 ---
 title: Configure Workspaces in Kong Manager
-badge: free
+badge: enterprise
 ---
 
 **Workspaces** enable an organization to segment traffic so that

--- a/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
@@ -1,15 +1,15 @@
 ---
 title: Invite an Admin
-badge: free
+badge: enterprise
 ---
 
-An **Admin** is any user in Kong Manager. They may access
-Kong entities within their assigned **Workspaces** based
-on the **Permissions** of their **Roles**.
+An Admin is any user in Kong Manager. They may access
+Kong entities within their assigned Workspaces based
+on the Permissions of their Roles.
 
-This guide describes how to invite an **Admin** in Kong
-Manager. As an alternative, if a **Super Admin** wants to
-invite an **Admin** with the Admin API, it is possible to
+This guide describes how to invite an Admin in Kong
+Manager. As an alternative, if a Super Admin wants to
+invite an Admin with the Admin API, it is possible to
 do so using
 [`/admins`](/gateway/{{page.kong_version}}/admin-api/admins/reference/#invite-an-admin).
 

--- a/app/gateway/2.6.x/configure/auth/rbac/add-role.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-role.md
@@ -1,6 +1,6 @@
 ---
 title: Add a Role and Permissions
-badge: free
+badge: enterprise
 ---
 
 Roles make it easy to logically group and apply the same

--- a/app/gateway/2.6.x/configure/auth/rbac/add-user.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-user.md
@@ -1,6 +1,6 @@
 ---
 title: Create an RBAC User
-badge: free
+badge: enterprise
 ---
 
 ## Admins vs. RBAC Users

--- a/app/gateway/2.6.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/index.md
@@ -1,6 +1,6 @@
 ---
 title: RBAC in Kong Manager
-badge: free
+badge: enterprise
 ---
 
 In addition to authenticating Admins and segmenting Workspaces,

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -4,7 +4,7 @@ title: Install on Kubernetes with Helm
 
 This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} using Helm.
 
-* The Enterprise deployment includes a Postgres sub-chart provided by Bitnami. 
+* The Enterprise deployment includes a Postgres sub-chart provided by Bitnami.
 * For open-source deployments, you can choose to use the Postgres sub-chart, or install without a database.
 
 Configuration for both options is flexible and depends on your environment.
@@ -111,7 +111,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
 
 ## Create values.yaml file
 
-Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. You can work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set. 
+Create a `values.yaml` file to provide required values such as password secrets or optional email addresses for notifications. You can work from the [Enterprise example file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml). The example file includes comments to explain which values you must set.
 
 For OSS deployments, the default install might be sufficient, but you can explore other `values.yaml` files and [the readme in the charts repository](https://github.com/Kong/charts/blob/main/charts/kong/README.md), which includes an exhaustive list of all possible configuration properties.
 
@@ -158,7 +158,7 @@ Note that the Enterprise deployment includes a Postgres sub-chart provided by Bi
     admin_api_uri: {YOUR-DNS-OR-IP}
     ```
 
-    {:.Note}
+    {:.note}
     > **Note:** If you configure RBAC, you must specify a DNS hostname instead of an IP address.
 
 1.  Clean up:

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -2,7 +2,7 @@
 title: Install on Kubernetes
 ---
 
-This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with [Helm](/gateway/{{page.kong_version}}/install-and-run/helm). 
+This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} in DB-less mode. To install with a database, see the documentation on installing with [Helm](/gateway/{{page.kong_version}}/install-and-run/helm).
 
 This page also includes the equivalent commands for OpenShift.
 
@@ -78,7 +78,7 @@ oc new-project kong
     oc get pods -n kong
     ```
 
-1.  To make HTTP requests, you need the IP address of the load balancer. Get the LoadBalancer address and store it in a local PROXY_IP environment variable: 
+1.  To make HTTP requests, you need the IP address of the load balancer. Get the LoadBalancer address and store it in a local PROXY_IP environment variable:
 
     ```sh
     export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
@@ -96,20 +96,9 @@ oc new-project kong
     oc get service kong-proxy -n kong
     ```
 
-    {:.Note}
+    {:.note}
     > **Note:** Some cluster providers provide only a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
 
 ## Next steps
 
 See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
-
-
-
-
-
-
-
-
-
-
-

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -45,6 +45,7 @@ oc new-project kong
     ```
 
 ## Create secret for RBAC superuser (recommended)
+{:.badge .enterprise}
 
 If you plan to use RBAC, you must create the superuser account at this step in installation. You cannot create it later.
 
@@ -138,7 +139,7 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
     admin_api_uri: <your-DNS-or-IP>
     ```
 
-    {:.Note}
+    {:.note}
     > **Note:** If you configure RBAC, you must specify a DNS hostname instead of an IP address.
 
 1.  Clean up:

--- a/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade Kong Gateway
-badge: enterprise
+badge: free
 ---
 
 Upgrade to major, minor, and patch {{site.ee_product_name}} releases using the

--- a/app/gateway/2.6.x/plan-and-deploy/default-ports.md
+++ b/app/gateway/2.6.x/plan-and-deploy/default-ports.md
@@ -10,7 +10,7 @@ By default, {{site.base_gateway}} listens on the following ports:
 | [`:8001`](/gateway/{{page.kong_version}}/reference/configuration/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
 | [`:8444`](/gateway/{{page.kong_version}}/reference/configuration/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
 | [`:8005`](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
-| [`:8006`](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | All tiers and modes |
+| [`:8006`](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | {{site.base_gateway}} Enterprise tier |
 | [`:8002`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |
 | [`:8445`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | {{site.base_gateway}} free mode |
 | [`:8003`](/gateway/{{page.kong_version}}/reference/configuration/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |

--- a/app/gateway/2.6.x/plan-and-deploy/security/start-kong-securely.md
+++ b/app/gateway/2.6.x/plan-and-deploy/security/start-kong-securely.md
@@ -1,6 +1,6 @@
 ---
 title: Start Kong Gateway Securely
-badge: free
+badge: enterprise
 ---
 
 To secure the Admin API or Kong Manager, a Super Admin account is


### PR DESCRIPTION
### Summary
Changing "Free" labels on RBAC topics and sections to "Enterprise". 

### Reason
RBAC and workspaces are enterprise features and are not available in Free mode.

### Testing
Tested locally. 

