### PR TITLE
[DOCU-2023] Licensing and install path info

### DIFF
--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -142,29 +142,33 @@ By default, {{site.kong_gateway}} listens on the following ports:
 
 5. Access Kong Manager on port `8002`.
 
+### Deploy a license
+{:.badge .enterprise}
+
+If you have an Enterprise subscription, follow the instructions to 
+[deploy a license](/gateway/{{include.kong_version}}/plan-and-deploy/licenses/deploy-license).
+
 ### Enable Dev Portal
 {:.badge .enterprise}
 
-1. [Deploy a license](/gateway/{{include.kong_version}}/plan-and-deploy/licenses/deploy-license).
-
-2. Enable the Dev Portal in the `kong.conf` file by setting the `portal` property to `on` and the
+1. Enable the Dev Portal in the `kong.conf` file by setting the `portal` property to `on` and the
    `portal_gui_host` property to the DNS or IP address of the Amazon Linux system.
    For example:
 
     <div class="copy-code-snippet"><pre><code>portal = on
     portal_gui_host = <div contenteditable="true">{DNS_OR_IP}</div>:8003</code></pre></div>
 
-3. Restart {{site.base_gateway}} for the setting to take effect, using the following command:
+1. Restart {{site.base_gateway}} for the setting to take effect, using the following command:
 
     <div class="copy-code-snippet"><pre><code>kong restart -c <div contenteditable="true">{PATH_TO_KONG.CONF_FILE}</div></code></pre></div>
 
-4. To enable the Dev Portal for a workspace. Execute the following command,
+1. To enable the Dev Portal for a workspace. Execute the following command,
    updating `DNSorIP` to reflect the IP or valid DNS for the OS system:
 
     <div class="copy-code-snippet"><pre><code>curl -X PATCH http://<div contenteditable="true">{DNS_OR_IP}</div>:8001/workspaces/default \
     --data "config.portal=true"</code></pre></div>
 
-5. Access the Dev Portal for the default workspace using the following URL,
+1. Access the Dev Portal for the default workspace using the following URL,
    substituting your own DNS or IP:
 
     <div class="copy-code-snippet"><pre><code>http://<div contenteditable="true">{DNS_OR_IP}</div>:8003/default</code></pre></div>
@@ -181,6 +185,3 @@ your setup, reach out to your Kong Support contact or go to the
 Check out {{site.base_gateway}}'s series of
 [Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive) guides to get the most
 out of {{site.base_gateway}}.
-
-If you have an Enterprise subscription, add the license using the
-[`/licenses` Admin API endpoint](/gateway/{{include.kong_version}}/plan-and-deploy/licenses/deploy-license).

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -162,7 +162,7 @@ If you have an Enterprise subscription, follow the instructions to
 
     <div class="copy-code-snippet"><pre><code>kong restart -c <div contenteditable="true">{PATH_TO_KONG.CONF_FILE}</div></code></pre></div>
 
-1. To enable the Dev Portal for a workspace. Execute the following command,
+1. To enable the Dev Portal for a workspace, execute the following command,
    updating `DNSorIP` to reflect the IP or valid DNS for the OS system:
 
     <div class="copy-code-snippet"><pre><code>curl -X PATCH http://<div contenteditable="true">{DNS_OR_IP}</div>:8001/workspaces/default \

--- a/app/gateway/2.6.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.6.x/install-and-run/amazon-linux.md
@@ -15,9 +15,15 @@ title: Install Kong Gateway on Amazon Linux
 > <span class="install-subtitle">View the list of all 2.x packages for
 > [Amazon Linux 1]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/){:.install-listing-link} and [Amazon Linux 2]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/){:.install-listing-link}  </span>
 
+The {{site.base_gateway}} software is governed by the 
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
-You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* (Enterprise only) A `license.json` file from Kong.
 
 ## Download
 

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -21,9 +21,16 @@ title: Install Kong Gateway on CentOS
 > [**CentOS 7**]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/){:.install-listing-link} or
 > [**CentOS 8**]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/){:.install-listing-link} </span>
 
+
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
-You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* (Enterprise only) A `license.json` file from Kong.
 
 ## Download
 

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -19,6 +19,9 @@ badge: oss
 > [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}
 >  </span>
 
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
 You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -25,12 +25,15 @@ are not publicly accessible. If you need a specific patch version and can't
 find it on [Kong's public Docker Hub page](https://hub.docker.com/r/kong/kong-gateway), contact
 [Kong Support](https://support.konghq.com/).
 
-This software is governed by the
+The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
 
-For this installation, you'll need a Docker-enabled system with proper Docker access.
+* A Docker-enabled system with proper Docker access
+* (Enterprise only) A `license.json` file from Kong
 
 ## Install Kong Gateway with a database
 
@@ -309,6 +312,3 @@ setup, reach out to your support contact or head over to the
 Check out {{site.base_gateway}}'s series of
 [Getting Started](/gateway/{{page.kong_version}}/get-started/comprehensive/) guides to get the most
 out of {{site.base_gateway}}.
-
-If you have an Enterprise subscription, add the license using the
-[`/licenses` Admin API endpoint](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license).

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -11,6 +11,11 @@ Configuration for both options is flexible and depends on your environment.
 
 The documentation on installing with a [flat Kubernetes manifest](/gateway/{{page.kong_version}}/install-and-run/kubernetes) also explains how to install in DB-less mode for both Enterprise and OSS deployments.
 
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
 - A Kubernetes cluster, v1.19 or later

--- a/app/gateway/2.6.x/install-and-run/index.md
+++ b/app/gateway/2.6.x/install-and-run/index.md
@@ -64,22 +64,22 @@ disable_image_expand: true
 
 {% include_cached /md/gateway/deployment-options.md kong_version=page.kong_version %}
 
-### Licensing
+### Installation paths
 
-This software is governed by the
-[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+Some installation topics provide multiple package types and installation options.
+Choose your preferred mode when following installation steps:
 
-To enable Enterprise features, {{site.base_gateway}} requires a license file.
-You will receive this file from Kong when you sign up for a
-{{site.konnect_product_name}} Enterprise subscription.
+* **Open-source**: Follow installation instructions and skip any Free or Enterprise steps.
+* **Free Mode**: Install {{site.base_gateway}} without a license, gaining access to Kong Manager.
+* **Enterprise**: Install {{site.base_gateway}} and add a license.
 
-Once a license has been deployed to a {{site.base_gateway}} node, retrieve it
-using the [`/licenses` Admin API endpoint](/gateway/{{page.kong_version}}/admin-api/licenses/examples).
-
-If you have purchased a subscription but haven't received a license file,
-contact your sales representative.
+If you install the {{site.base_gateway}} (not open-source), you can add a license
+at any time to gain access to Enterprise features.
 
 {:.note}
-> **Note:** The free mode does not require a license. See
-[Kong Gateway Licensing](/gateway/{{page.kong_version}}/plan-and-deploy/licenses)
-for a feature comparison.
+> **Note**: For deployments on Kubernetes (including Helm and OpenShift),
+you need to apply the license during installation.
+
+See [Kong Gateway Licensing](/gateway/{{include.kong_version}}/plan-and-deploy/licenses)
+for a feature comparison between Free Mode and the Enterprise subscription,
+and more information about licenses.

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -8,6 +8,11 @@ This page also includes the equivalent commands for OpenShift.
 
 Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native datastore. For more information see [Kubernetes Deployment Options](/gateway/{{page.kong_version}}/plan-and-deploy/kubernetes-deployment-options).
 
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
 - A Kubernetes cluster, v1.19 or later

--- a/app/gateway/2.6.x/install-and-run/macos.md
+++ b/app/gateway/2.6.x/install-and-run/macos.md
@@ -11,6 +11,9 @@ badge: oss
 >
 > (latest version: {{page.kong_versions[page.version-index].ce-version}})
 
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
 You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
@@ -104,7 +107,7 @@ you should start by generating a declarative config file.
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/gateway/{{include.kong_version}}/get-started/overview) guides to get the most
+[Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive) guides to get the most
 out of {{site.base_gateway}}.
 
 [configuration]: /gateway/latest/reference/configuration#database

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -5,6 +5,12 @@ badge: enterprise
 
 This page explains how to install {{site.base_gateway}} with {{site.kic_product_name}} with a database. To install in DB-less mode, see the documentation on installing with a [flat Kubernetes manifest](/gateway/{{page.kong_version}}/install-and-run/kubernetes).
 
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
+
 ## Prerequisites
 
 - A Kubernetes cluster, v1.19 or later

--- a/app/gateway/2.6.x/install-and-run/rhel.md
+++ b/app/gateway/2.6.x/install-and-run/rhel.md
@@ -21,10 +21,16 @@ title: Install Kong Gateway on RHEL
 > [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/){:.install-listing-link} or
 > [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/){:.install-listing-link}<span>
 
+
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
-You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
-
+* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* (Enterprise only) A `license.json` file from Kong
 
 ## Download
 

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -25,9 +25,16 @@ title: Install Kong Gateway on Ubuntu
 > [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/){:.install-listing-link}
 >  </span>
 
+
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
+{{site.ce_product_name}} is licensed under an
+[Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
 ## Prerequisites
 
-You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* (Enterprise only) A `license.json` file from Kong
 
 ## Download
 


### PR DESCRIPTION
### Summary
* Add links to license agreements from installation pages
* Attempt to provide a better install path summary on overview page (this info is useful but I really don't want to include it on each page)
* Add "deploy license" section to install include, so that it's not part of setting up Dev Portal. Not sure if this really fits.

### Reason
Feedback from PM, see https://konghq.atlassian.net/browse/DOCU-2023

### Testing
Tested locally.
